### PR TITLE
Implement X509KeyStore using stdlib tls.Certificate

### DIFF
--- a/tls_keystore.go
+++ b/tls_keystore.go
@@ -1,0 +1,34 @@
+package dsig
+
+import (
+	"crypto/rsa"
+	"crypto/tls"
+	"fmt"
+)
+
+//Well-known errors
+var (
+	ErrNonRSAKey           = fmt.Errorf("Private key was not RSA")
+	ErrMissingCertificates = fmt.Errorf("No public certificates provided")
+)
+
+//TLSCertKeyStore wraps the stdlib tls.Certificate to return its contained key
+//and certs.
+type TLSCertKeyStore tls.Certificate
+
+//GetKeyPair implements X509KeyStore using the underlying tls.Certificate
+func (d TLSCertKeyStore) GetKeyPair() (*rsa.PrivateKey, []byte, error) {
+	pk, ok := d.PrivateKey.(*rsa.PrivateKey)
+
+	if !ok {
+		return nil, nil, ErrNonRSAKey
+	}
+
+	if len(d.Certificate) < 1 {
+		return nil, nil, ErrMissingCertificates
+	}
+
+	crt := d.Certificate[0]
+
+	return pk, crt, nil
+}


### PR DESCRIPTION
This should enable a little more flexibility in the cases where the certificates have already been loaded via [tls.LoadX509KeyPair](https://golang.org/pkg/crypto/tls/#LoadX509KeyPair). This is currently useful for the work I'm doing on russellhaering/gosaml2#3  for supporting EncryptedAssertions.