### PR TITLE
Initial exc-c14n implementation

### DIFF
--- a/canonicalize.go
+++ b/canonicalize.go
@@ -1,6 +1,7 @@
 package dsig
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/beevik/etree"
@@ -11,9 +12,9 @@ type attrsByKey []etree.Attr
 func composeAttr(space, key string) string {
 	if space != "" {
 		return space + ":" + key
-	} else {
-		return key
 	}
+
+	return key
 }
 
 func (a attrsByKey) Len() int {
@@ -35,9 +36,8 @@ func (a attrsByKey) Less(i, j int) bool {
 	if a[i].Space == "xmlns" {
 		if a[j].Space == "xmlns" {
 			return a[i].Key < a[j].Key
-		} else {
-			return true
 		}
+		return true
 	}
 
 	if a[j].Space == "xmlns" {
@@ -47,8 +47,8 @@ func (a attrsByKey) Less(i, j int) bool {
 	return composeAttr(a[i].Space, a[i].Key) < composeAttr(a[j].Space, a[j].Key)
 }
 
-func _canonicalHack(el *etree.Element, seenSoFar map[string]bool) *etree.Element {
-	_seenSoFar := make(map[string]bool)
+func _canonicalHack(el *etree.Element, seenSoFar map[string]struct{}) *etree.Element {
+	_seenSoFar := make(map[string]struct{})
 	for k, v := range seenSoFar {
 		_seenSoFar[k] = v
 	}
@@ -61,10 +61,10 @@ func _canonicalHack(el *etree.Element, seenSoFar map[string]bool) *etree.Element
 				continue
 			}
 			key := attr.Space + ":" + attr.Key
-			if _seenSoFar[key] {
+			if _, seen := _seenSoFar[key]; seen {
 				ne.RemoveAttr(attr.Space + ":" + attr.Key)
 			} else {
-				_seenSoFar[key] = true
+				_seenSoFar[key] = struct{}{}
 			}
 		}
 	}
@@ -84,8 +84,76 @@ func _canonicalHack(el *etree.Element, seenSoFar map[string]bool) *etree.Element
 // any other other shortcomings until I can get the fixes upstream.
 // NOTE(phoebe): Looks like etree also doesn't remove attributes that are
 // duplicate namespaces. They should be removed if a parent has a matching one
+// NOTE(astuart): namespaces must also be moved to the first element at which they're used
 func canonicalHack(el *etree.Element) *etree.Element {
-	attrMap := make(map[string]bool)
+	attrMap := make(map[string]struct{})
 	return _canonicalHack(el, attrMap)
+}
 
+func getNsDecl(a etree.Attr) string {
+	return fmt.Sprintf("xmlns:%s", a.Key)
+}
+
+type c14nSpace struct {
+	a    etree.Attr
+	used bool
+}
+
+const nsSpace = "xmlns"
+
+func _excCanonicalPrep(el *etree.Element, _alreadyDeclared map[string]c14nSpace) *etree.Element {
+	//Copy alreadyDeclared map
+	alreadyDeclared := make(map[string]c14nSpace, len(_alreadyDeclared))
+	for k := range _alreadyDeclared {
+		alreadyDeclared[k] = _alreadyDeclared[k]
+	}
+
+	usedHere := make(map[string]struct{})
+
+	if el.Space != "" {
+		usedHere[el.Space] = struct{}{}
+	}
+
+	toRemove := make([]string, 0, 0)
+
+	for _, a := range el.Attr {
+		switch a.Space {
+		case nsSpace:
+			toRemove = append(toRemove, a.Space+":"+a.Key)
+			if _, ok := alreadyDeclared[a.Key]; !ok {
+				alreadyDeclared[a.Key] = c14nSpace{a: a, used: false}
+			}
+		default:
+			if a.Space != "" {
+				usedHere[a.Space] = struct{}{}
+			}
+		}
+	}
+	for _, attrK := range toRemove {
+		el.RemoveAttr(attrK)
+	}
+
+	for k := range usedHere {
+		spc := alreadyDeclared[k]
+		//If previously unused, mark as used
+		if !spc.used {
+			el.Attr = append(el.Attr, spc.a)
+			spc.used = true
+			alreadyDeclared[k] = spc
+		}
+	}
+
+	for _, child := range el.ChildElements() {
+		_excCanonicalPrep(child, alreadyDeclared)
+	}
+
+	sort.Sort(attrsByKey(el.Attr))
+
+	//Sort
+
+	return el.Copy()
+}
+
+func excCanonicalPrep(el *etree.Element) *etree.Element {
+	return _excCanonicalPrep(el, make(map[string]c14nSpace))
 }

--- a/canonicalize_test.go
+++ b/canonicalize_test.go
@@ -1,0 +1,41 @@
+package dsig
+
+import (
+	"testing"
+
+	"github.com/beevik/etree"
+)
+
+const (
+	assertion       = `<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_88a93ebe-abdf-48cd-9ed0-b0dd1b252909" Version="2.0" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="https://saml2.test.astuart.co/sso/saml2" AssertionConsumerServiceIndex="0" AttributeConsumingServiceIndex="0" IssueInstant="2016-04-28T15:37:17" Destination="http://idp.astuart.co/idp/profile/SAML2/Redirect/SSO"><saml:Issuer>https://saml2.test.astuart.co/sso/saml2</saml:Issuer><samlp:NameIDPolicy AllowCreate="true" Format=""/><samlp:RequestedAuthnContext Comparison="exact"><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>`
+	actual          = `<samlp:AuthnRequest xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" AssertionConsumerServiceIndex="0" AssertionConsumerServiceURL="https://saml2.test.astuart.co/sso/saml2" AttributeConsumingServiceIndex="0" Destination="http://idp.astuart.co/idp/profile/SAML2/Redirect/SSO" ID="_88a93ebe-abdf-48cd-9ed0-b0dd1b252909" IssueInstant="2016-04-28T15:37:17" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Version="2.0"><saml:Issuer>https://saml2.test.astuart.co/sso/saml2</saml:Issuer><samlp:NameIDPolicy AllowCreate="true" Format=""></samlp:NameIDPolicy><samlp:RequestedAuthnContext Comparison="exact"><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>`
+	assertionC14ned = `<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" AssertionConsumerServiceIndex="0" AssertionConsumerServiceURL="https://saml2.test.astuart.co/sso/saml2" AttributeConsumingServiceIndex="0" Destination="http://idp.astuart.co/idp/profile/SAML2/Redirect/SSO" ID="_88a93ebe-abdf-48cd-9ed0-b0dd1b252909" IssueInstant="2016-04-28T15:37:17" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Version="2.0"><saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">https://saml2.test.astuart.co/sso/saml2</saml:Issuer><samlp:NameIDPolicy AllowCreate="true" Format=""></samlp:NameIDPolicy><samlp:RequestedAuthnContext Comparison="exact"><saml:AuthnContextClassRef xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>`
+)
+
+func TestC14N10(t *testing.T) {
+	raw := etree.NewDocument()
+
+	raw.ReadFromString(assertion)
+
+	hacked := excCanonicalPrep(raw.Root())
+
+	hd := etree.NewDocument()
+
+	hd.SetRoot(hacked)
+
+	hd.WriteSettings = etree.WriteSettings{
+		CanonicalAttrVal: true,
+		CanonicalEndTags: true,
+	}
+
+	hs, err := hd.WriteToString()
+	if err != nil {
+		t.Fatalf("could not write c14n doc: %v", err)
+	}
+
+	if hs != assertionC14ned {
+		t.Log(hs)
+		t.Log(assertionC14ned)
+		t.Errorf("Wrong canonical representation.")
+	}
+}

--- a/canonicalize_test.go
+++ b/canonicalize_test.go
@@ -8,11 +8,11 @@ import (
 
 const (
 	assertion       = `<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_88a93ebe-abdf-48cd-9ed0-b0dd1b252909" Version="2.0" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="https://saml2.test.astuart.co/sso/saml2" AssertionConsumerServiceIndex="0" AttributeConsumingServiceIndex="0" IssueInstant="2016-04-28T15:37:17" Destination="http://idp.astuart.co/idp/profile/SAML2/Redirect/SSO"><saml:Issuer>https://saml2.test.astuart.co/sso/saml2</saml:Issuer><samlp:NameIDPolicy AllowCreate="true" Format=""/><samlp:RequestedAuthnContext Comparison="exact"><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>`
-	actual          = `<samlp:AuthnRequest xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" AssertionConsumerServiceIndex="0" AssertionConsumerServiceURL="https://saml2.test.astuart.co/sso/saml2" AttributeConsumingServiceIndex="0" Destination="http://idp.astuart.co/idp/profile/SAML2/Redirect/SSO" ID="_88a93ebe-abdf-48cd-9ed0-b0dd1b252909" IssueInstant="2016-04-28T15:37:17" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Version="2.0"><saml:Issuer>https://saml2.test.astuart.co/sso/saml2</saml:Issuer><samlp:NameIDPolicy AllowCreate="true" Format=""></samlp:NameIDPolicy><samlp:RequestedAuthnContext Comparison="exact"><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>`
+	c14n11          = `<samlp:AuthnRequest xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" AssertionConsumerServiceIndex="0" AssertionConsumerServiceURL="https://saml2.test.astuart.co/sso/saml2" AttributeConsumingServiceIndex="0" Destination="http://idp.astuart.co/idp/profile/SAML2/Redirect/SSO" ID="_88a93ebe-abdf-48cd-9ed0-b0dd1b252909" IssueInstant="2016-04-28T15:37:17" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Version="2.0"><saml:Issuer>https://saml2.test.astuart.co/sso/saml2</saml:Issuer><samlp:NameIDPolicy AllowCreate="true" Format=""></samlp:NameIDPolicy><samlp:RequestedAuthnContext Comparison="exact"><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>`
 	assertionC14ned = `<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" AssertionConsumerServiceIndex="0" AssertionConsumerServiceURL="https://saml2.test.astuart.co/sso/saml2" AttributeConsumingServiceIndex="0" Destination="http://idp.astuart.co/idp/profile/SAML2/Redirect/SSO" ID="_88a93ebe-abdf-48cd-9ed0-b0dd1b252909" IssueInstant="2016-04-28T15:37:17" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Version="2.0"><saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">https://saml2.test.astuart.co/sso/saml2</saml:Issuer><samlp:NameIDPolicy AllowCreate="true" Format=""></samlp:NameIDPolicy><samlp:RequestedAuthnContext Comparison="exact"><saml:AuthnContextClassRef xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>`
 )
 
-func TestC14N10(t *testing.T) {
+func TestExcC14N10(t *testing.T) {
 	raw := etree.NewDocument()
 
 	raw.ReadFromString(assertion)
@@ -36,6 +36,34 @@ func TestC14N10(t *testing.T) {
 	if hs != assertionC14ned {
 		t.Log(hs)
 		t.Log(assertionC14ned)
+		t.Errorf("Wrong canonical representation.")
+	}
+}
+
+func TestC14N11(t *testing.T) {
+	raw := etree.NewDocument()
+
+	raw.ReadFromString(assertion)
+
+	hacked := canonicalHack(raw.Root())
+
+	hd := etree.NewDocument()
+
+	hd.SetRoot(hacked)
+
+	hd.WriteSettings = etree.WriteSettings{
+		CanonicalAttrVal: true,
+		CanonicalEndTags: true,
+	}
+
+	hs, err := hd.WriteToString()
+	if err != nil {
+		t.Fatalf("could not write c14n doc: %v", err)
+	}
+
+	if hs != c14n11 {
+		t.Log(hs)
+		t.Log(c14n11)
 		t.Errorf("Wrong canonical representation.")
 	}
 }

--- a/sign.go
+++ b/sign.go
@@ -17,7 +17,7 @@ type SigningContext struct {
 	KeyStore    X509KeyStore
 	IdAttribute string
 	Prefix      string
-	Algorithm   string
+	Algorithm   SignatureAlgorithm
 }
 
 func NewDefaultSigningContext(ks X509KeyStore) *SigningContext {
@@ -76,7 +76,7 @@ func (ctx *SigningContext) constructSignedInfo(el *etree.Element, enveloped bool
 
 	// /SignedInfo/CanonicalizationMethod
 	canonicalizationMethod := ctx.createNamespacedElement(signedInfo, CanonicalizationMethodTag)
-	canonicalizationMethod.CreateAttr(AlgorithmAttr, ctx.Algorithm)
+	canonicalizationMethod.CreateAttr(AlgorithmAttr, string(ctx.Algorithm))
 
 	// /SignedInfo/SignatureMethod
 	signatureMethod := ctx.createNamespacedElement(signedInfo, SignatureMethodTag)
@@ -99,7 +99,7 @@ func (ctx *SigningContext) constructSignedInfo(el *etree.Element, enveloped bool
 		envelopedTransform.CreateAttr(AlgorithmAttr, EnvelopedSignatureAltorithmId)
 	}
 	canonicalizationAlgorithm := ctx.createNamespacedElement(transforms, TransformTag)
-	canonicalizationAlgorithm.CreateAttr(AlgorithmAttr, ctx.Algorithm)
+	canonicalizationAlgorithm.CreateAttr(AlgorithmAttr, string(ctx.Algorithm))
 
 	// /SignedInfo/Reference/DigestMethod
 	digestMethod := ctx.createNamespacedElement(reference, DigestMethodTag)

--- a/sign.go
+++ b/sign.go
@@ -17,6 +17,7 @@ type SigningContext struct {
 	KeyStore    X509KeyStore
 	IdAttribute string
 	Prefix      string
+	Algorithm   string
 }
 
 func NewDefaultSigningContext(ks X509KeyStore) *SigningContext {
@@ -25,12 +26,18 @@ func NewDefaultSigningContext(ks X509KeyStore) *SigningContext {
 		KeyStore:    ks,
 		IdAttribute: DefaultIdAttr,
 		Prefix:      DefaultPrefix,
+		Algorithm:   CanonicalXML11AlgorithmId,
 	}
 }
 
 func (ctx *SigningContext) digest(el *etree.Element) ([]byte, error) {
 	doc := etree.NewDocument()
-	doc.SetRoot(canonicalHack(el))
+	switch ctx.Algorithm {
+	case CanonicalXML10AlgorithmId:
+		doc.SetRoot(excCanonicalPrep(el))
+	default:
+		doc.SetRoot(canonicalHack(el))
+	}
 	doc.WriteSettings = etree.WriteSettings{
 		CanonicalAttrVal: true,
 		CanonicalEndTags: true,
@@ -69,7 +76,7 @@ func (ctx *SigningContext) constructSignedInfo(el *etree.Element, enveloped bool
 
 	// /SignedInfo/CanonicalizationMethod
 	canonicalizationMethod := ctx.createNamespacedElement(signedInfo, CanonicalizationMethodTag)
-	canonicalizationMethod.CreateAttr(AlgorithmAttr, CanonicalXML11AlgorithmId)
+	canonicalizationMethod.CreateAttr(AlgorithmAttr, ctx.Algorithm)
 
 	// /SignedInfo/SignatureMethod
 	signatureMethod := ctx.createNamespacedElement(signedInfo, SignatureMethodTag)
@@ -92,7 +99,7 @@ func (ctx *SigningContext) constructSignedInfo(el *etree.Element, enveloped bool
 		envelopedTransform.CreateAttr(AlgorithmAttr, EnvelopedSignatureAltorithmId)
 	}
 	canonicalizationAlgorithm := ctx.createNamespacedElement(transforms, TransformTag)
-	canonicalizationAlgorithm.CreateAttr(AlgorithmAttr, CanonicalXML11AlgorithmId)
+	canonicalizationAlgorithm.CreateAttr(AlgorithmAttr, ctx.Algorithm)
 
 	// /SignedInfo/Reference/DigestMethod
 	digestMethod := ctx.createNamespacedElement(reference, DigestMethodTag)

--- a/validate.go
+++ b/validate.go
@@ -89,7 +89,7 @@ func (ctx *ValidationContext) transform(root, sig *etree.Element, transforms []*
 			if !recursivelyRemoveElement(root, sig) {
 				return nil, "", errors.New("Error applying canonicalization transform: Signature not found")
 			}
-		case CanonicalXML10AlgorithmId, CanonicalXML11AlgorithmId:
+		case string(CanonicalXML10AlgorithmId), string(CanonicalXML11AlgorithmId):
 			c14nAlgorithm = algo.Value
 		default:
 			return nil, "", errors.New("Unknown Transform Algorithm: " + algo.Value)

--- a/xml_constants.go
+++ b/xml_constants.go
@@ -30,10 +30,15 @@ const (
 	DefaultIdAttr = "ID"
 )
 
+type SignatureAlgorithm string
+
+//Well-known signature algorithms
 const (
 	// NOTE(russell_h): I guess 1.0 is "exclusive" and 1.1 isn't
-	CanonicalXML10AlgorithmId     = "http://www.w3.org/2001/10/xml-exc-c14n#"
-	CanonicalXML11AlgorithmId     = "http://www.w3.org/2006/12/xml-c14n11"
+	CanonicalXML10AlgorithmId SignatureAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#"
+	CanonicalXML11AlgorithmId                    = "http://www.w3.org/2006/12/xml-c14n11"
+)
+const (
 	EnvelopedSignatureAltorithmId = "http://www.w3.org/2000/09/xmldsig#enveloped-signature"
 )
 


### PR DESCRIPTION
This implements an algorithm and a test (using a tree generated by the library) for xml-exc-c14n, as well as a new attribute in the context so that the desired algorithm can be set.

EDIT: had to remove this 'cuz it broke signature validation on requests coming from shib. ~~I also fixed a minor bug I ran across for the canonicalHack for the case when there are multiple namespaces on a single element -- the canonicalHack algorithm will miss certain elements if they've been removed during the range operation.~~