### PR TITLE
Add support for SHA512.

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -14,6 +14,7 @@ import (
 )
 
 var uriRegexp = regexp.MustCompile("^#[a-zA-Z_][\\w.-]*$")
+var wordWrappingRegexp = regexp.MustCompile("[ \t\r\n]+")
 
 type ValidationContext struct {
 	CertificateStore X509CertificateStore
@@ -249,7 +250,9 @@ func (ctx *ValidationContext) validateSignature(el *etree.Element, cert *x509.Ce
 		return nil, err
 	}
 
-	if digestValue.Text() != base64.StdEncoding.EncodeToString(digest) {
+	// Allow the digest to wrap multiple lines
+	digested := wordWrappingRegexp.ReplaceAllString(digestValue.Text(), "")
+	if digested != base64.StdEncoding.EncodeToString(digest) {
 		return nil, errors.New("Signature could not be verified")
 	}
 

--- a/xml_constants.go
+++ b/xml_constants.go
@@ -45,6 +45,7 @@ const (
 var digestAlgorithmIdentifiers = map[crypto.Hash]string{
 	crypto.SHA1:   "http://www.w3.org/2000/09/xmldsig#sha1",
 	crypto.SHA256: "http://www.w3.org/2001/04/xmlenc#sha256",
+	crypto.SHA512: "http://www.w3.org/2001/04/xmlenc#sha512",
 }
 
 var digestAlgorithmsByIdentifier = map[string]crypto.Hash{}
@@ -62,4 +63,5 @@ func init() {
 var signatureMethodIdentifiers = map[crypto.Hash]string{
 	crypto.SHA1:   "http://www.w3.org/2000/09/xmldsig#rsa-sha1",
 	crypto.SHA256: "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+	crypto.SHA512: "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512",
 }


### PR DESCRIPTION
Howdy!

My local Shibboleth site uses SHA-512 for token exchange; this pull request adds support for it.
