### PR TITLE
Make sure to canonicalize with the proper method when validating

### DIFF
--- a/canonicalize.go
+++ b/canonicalize.go
@@ -170,3 +170,13 @@ func _excCanonicalPrep(el *etree.Element, _nsAlreadyDeclared map[string]c14nSpac
 func excCanonicalPrep(el *etree.Element) *etree.Element {
 	return _excCanonicalPrep(el, make(map[string]c14nSpace))
 }
+
+func canonicalize(el *etree.Element, canonicalizationMethod SignatureAlgorithm) *etree.Element {
+	switch canonicalizationMethod {
+	case CanonicalXML10AlgorithmId:
+		return excCanonicalPrep(el)
+	default:
+		return canonicalHack(el)
+	}
+
+}

--- a/sign.go
+++ b/sign.go
@@ -32,12 +32,7 @@ func NewDefaultSigningContext(ks X509KeyStore) *SigningContext {
 
 func (ctx *SigningContext) digest(el *etree.Element) ([]byte, error) {
 	doc := etree.NewDocument()
-	switch ctx.Algorithm {
-	case CanonicalXML10AlgorithmId:
-		doc.SetRoot(excCanonicalPrep(el))
-	default:
-		doc.SetRoot(canonicalHack(el))
-	}
+	doc.SetRoot(canonicalize(el, ctx.Algorithm))
 	doc.WriteSettings = etree.WriteSettings{
 		CanonicalAttrVal: true,
 		CanonicalEndTags: true,

--- a/validate.go
+++ b/validate.go
@@ -106,7 +106,8 @@ func (ctx *ValidationContext) transform(root, sig *etree.Element, transforms []*
 
 func (ctx *ValidationContext) digest(el *etree.Element, digestAlgorithmId, c14nAlgorithmId string) ([]byte, error) {
 	doc := etree.NewDocument()
-	doc.SetRoot(canonicalHack(el))
+	doc.SetRoot(canonicalize(el, SignatureAlgorithm(c14nAlgorithmId)))
+
 	doc.WriteSettings = etree.WriteSettings{
 		CanonicalAttrVal: true,
 		CanonicalEndTags: true,
@@ -140,7 +141,7 @@ func (ctx *ValidationContext) verifySignedInfo(signatureElement *etree.Element, 
 
 	// Canonicalize the xml
 	doc := etree.NewDocument()
-	doc.SetRoot(canonicalHack(signedInfo))
+	doc.SetRoot(canonicalize(signedInfo, SignatureAlgorithm(signatureMethodId)))
 	doc.WriteSettings = etree.WriteSettings{
 		CanonicalAttrVal: true,
 		CanonicalEndTags: true,


### PR DESCRIPTION
*What*
Ensures that we use the necessary canonicalization method when validating a response

*How*
canonicalize.go: new function that calls the proper canonicalization function based on the canonicalization method
sign.go: use new canonicalize function
validate.go: use new canonicalize function

*Why*
Ran into a case of this in the wild where a response was using `http://www.w3.org/2001/10/xml-exc-c14n#`, with some of the eccentricities specific to that method, and couldn't be verified because we default to `http://www.w3.org/2006/12/xml-c14n11`