### PR TITLE
Add a mockable clock to ValidationContext

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -47,3 +47,9 @@ func NewFakeClock(wrapped clockwork.Clock) *Clock {
 		wrapped: wrapped,
 	}
 }
+
+func NewFakeClockAt(t time.Time) *Clock {
+	return &Clock{
+		wrapped: clockwork.NewFakeClockAt(t),
+	}
+}

--- a/clock.go
+++ b/clock.go
@@ -6,6 +6,12 @@ import (
 	"github.com/jonboulle/clockwork"
 )
 
+// Clock wraps a clockwork.Clock (which could be real or fake) in order
+// to default to a real clock when a nil *Clock is used. In other words,
+// if you attempt to use a nil *Clock it will defer to the real system
+// clock. This allows Clock to be easily added to structs with methods
+// that currently reference the time package, without requiring every
+// instantiation of that struct to be updated.
 type Clock struct {
 	wrapped clockwork.Clock
 }

--- a/clock.go
+++ b/clock.go
@@ -1,0 +1,43 @@
+package dsig
+
+import (
+	"time"
+
+	"github.com/jonboulle/clockwork"
+)
+
+type Clock struct {
+	wrapped clockwork.Clock
+}
+
+func (c *Clock) getWrapped() clockwork.Clock {
+	if c == nil {
+		return clockwork.NewRealClock()
+	}
+
+	return c.wrapped
+}
+
+func (c *Clock) After(d time.Duration) <-chan time.Time {
+	return c.getWrapped().After(d)
+}
+
+func (c *Clock) Sleep(d time.Duration) {
+	c.getWrapped().Sleep(d)
+}
+
+func (c *Clock) Now() time.Time {
+	return c.getWrapped().Now()
+}
+
+func NewRealClock() *Clock {
+	return &Clock{
+		wrapped: clockwork.NewRealClock(),
+	}
+}
+
+func NewFakeClock(wrapped clockwork.Clock) *Clock {
+	return &Clock{
+		wrapped: wrapped,
+	}
+}

--- a/validate.go
+++ b/validate.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"time"
 
 	"github.com/beevik/etree"
 )
@@ -19,6 +18,7 @@ var wordWrappingRegexp = regexp.MustCompile("[ \t\r\n]+")
 type ValidationContext struct {
 	CertificateStore X509CertificateStore
 	IdAttribute      string
+	Clock            *Clock
 }
 
 func NewDefaultValidationContext(certificateStore X509CertificateStore) *ValidationContext {
@@ -298,7 +298,7 @@ func contains(roots []*x509.Certificate, cert *x509.Certificate) bool {
 }
 
 func (ctx *ValidationContext) verifyCertificate(el *etree.Element) (*x509.Certificate, error) {
-	now := time.Now()
+	now := ctx.Clock.Now()
 	el = el.Copy()
 
 	idAttr := el.SelectAttr(DefaultIdAttr)


### PR DESCRIPTION
This change adds a mockable clock to the `ValidationContext` struct. When the clock is unset it defers to system time, but the clock can be explicitly set to a fake clock for mocking.

I'm using https://github.com/jonboulle/clockwork for mocking the clock, but added a wrapper struct to avoid breaking our API by requiring a clock to be explicitly set outside of tests.