### PR TITLE
Fix canonicalization algorithm selection

### DIFF
--- a/canonicalize.go
+++ b/canonicalize.go
@@ -171,12 +171,12 @@ func excCanonicalPrep(el *etree.Element) *etree.Element {
 	return _excCanonicalPrep(el, make(map[string]c14nSpace))
 }
 
-func canonicalize(el *etree.Element, canonicalizationMethod SignatureAlgorithm) *etree.Element {
+func canonicalize(el *etree.Element, canonicalizationMethod AlgorithmID) *etree.Element {
 	switch canonicalizationMethod {
-	case CanonicalXML10AlgorithmId:
+	case CanonicalXML10ExclusiveAlgorithmId:
 		return excCanonicalPrep(el)
+
 	default:
 		return canonicalHack(el)
 	}
-
 }

--- a/canonicalize.go
+++ b/canonicalize.go
@@ -171,12 +171,15 @@ func excCanonicalPrep(el *etree.Element) *etree.Element {
 	return _excCanonicalPrep(el, make(map[string]c14nSpace))
 }
 
-func canonicalize(el *etree.Element, canonicalizationMethod AlgorithmID) *etree.Element {
+func canonicalize(el *etree.Element, canonicalizationMethod AlgorithmID) (*etree.Element, error) {
 	switch canonicalizationMethod {
 	case CanonicalXML10ExclusiveAlgorithmId:
-		return excCanonicalPrep(el)
+		return excCanonicalPrep(el), nil
+
+	case CanonicalXML11AlgorithmId:
+		return canonicalHack(el), nil
 
 	default:
-		return canonicalHack(el)
+		return nil, fmt.Errorf("unknown canonicalization algorithm: %s", canonicalizationMethod.String())
 	}
 }

--- a/sign.go
+++ b/sign.go
@@ -31,8 +31,13 @@ func NewDefaultSigningContext(ks X509KeyStore) *SigningContext {
 }
 
 func (ctx *SigningContext) digest(el *etree.Element) ([]byte, error) {
+	canonical, err := canonicalize(el, ctx.Algorithm)
+	if err != nil {
+		return nil, err
+	}
+
 	doc := etree.NewDocument()
-	doc.SetRoot(canonicalize(el, ctx.Algorithm))
+	doc.SetRoot(canonical)
 	doc.WriteSettings = etree.WriteSettings{
 		CanonicalAttrVal: true,
 		CanonicalEndTags: true,
@@ -40,7 +45,7 @@ func (ctx *SigningContext) digest(el *etree.Element) ([]byte, error) {
 	}
 
 	hash := ctx.Hash.New()
-	_, err := doc.WriteTo(hash)
+	_, err = doc.WriteTo(hash)
 	if err != nil {
 		return nil, err
 	}

--- a/sign.go
+++ b/sign.go
@@ -17,7 +17,7 @@ type SigningContext struct {
 	KeyStore    X509KeyStore
 	IdAttribute string
 	Prefix      string
-	Algorithm   SignatureAlgorithm
+	Algorithm   AlgorithmID
 }
 
 func NewDefaultSigningContext(ks X509KeyStore) *SigningContext {
@@ -91,7 +91,7 @@ func (ctx *SigningContext) constructSignedInfo(el *etree.Element, enveloped bool
 	transforms := ctx.createNamespacedElement(reference, TransformsTag)
 	if enveloped {
 		envelopedTransform := ctx.createNamespacedElement(transforms, TransformTag)
-		envelopedTransform.CreateAttr(AlgorithmAttr, EnvelopedSignatureAltorithmId)
+		envelopedTransform.CreateAttr(AlgorithmAttr, EnvelopedSignatureAltorithmId.String())
 	}
 	canonicalizationAlgorithm := ctx.createNamespacedElement(transforms, TransformTag)
 	canonicalizationAlgorithm.CreateAttr(AlgorithmAttr, string(ctx.Algorithm))

--- a/sign_test.go
+++ b/sign_test.go
@@ -47,7 +47,7 @@ func TestSign(t *testing.T) {
 
 	canonicalizationMethodAttr := canonicalizationMethodElement.SelectAttr(AlgorithmAttr)
 	require.NotEmpty(t, canonicalizationMethodAttr)
-	require.Equal(t, CanonicalXML11AlgorithmId, canonicalizationMethodAttr.Value)
+	require.Equal(t, CanonicalXML11AlgorithmId.String(), canonicalizationMethodAttr.Value)
 
 	signatureMethodElement := signedInfo.FindElement("//" + SignatureMethodTag)
 	require.NotEmpty(t, signatureMethodElement)
@@ -71,7 +71,7 @@ func TestSign(t *testing.T) {
 
 	algorithmAttr := transformElement.SelectAttr(AlgorithmAttr)
 	require.NotEmpty(t, algorithmAttr)
-	require.Equal(t, EnvelopedSignatureAltorithmId, algorithmAttr.Value)
+	require.Equal(t, EnvelopedSignatureAltorithmId.String(), algorithmAttr.Value)
 
 	digestMethodElement := referenceElement.FindElement("//" + DigestMethodTag)
 	require.NotEmpty(t, digestMethodElement)

--- a/validate.go
+++ b/validate.go
@@ -128,7 +128,7 @@ func (ctx *ValidationContext) digest(el *etree.Element, digestAlgorithmId, c14nA
 	return hash.Sum(nil), nil
 }
 
-func (ctx *ValidationContext) verifySignedInfo(signatureElement *etree.Element, signatureMethodId string, cert *x509.Certificate, sig []byte) error {
+func (ctx *ValidationContext) verifySignedInfo(signatureElement *etree.Element, c14nAlgorithmId, signatureMethodId string, cert *x509.Certificate, sig []byte) error {
 	signedInfo := signatureElement.FindElement(childPath(signatureElement.Space, SignedInfoTag))
 	if signedInfo == nil {
 		return errors.New("Missing SignedInfo")
@@ -141,7 +141,7 @@ func (ctx *ValidationContext) verifySignedInfo(signatureElement *etree.Element, 
 
 	// Canonicalize the xml
 	doc := etree.NewDocument()
-	doc.SetRoot(canonicalize(signedInfo, AlgorithmID(signatureMethod)))
+	doc.SetRoot(canonicalize(signedInfo, AlgorithmID(c14nAlgorithmId)))
 	doc.WriteSettings = etree.WriteSettings{
 		CanonicalAttrVal: true,
 		CanonicalEndTags: true,
@@ -280,7 +280,7 @@ func (ctx *ValidationContext) validateSignature(el *etree.Element, cert *x509.Ce
 		return nil, errors.New("Could not decode signature")
 	}
 	// Actually verify the 'SignedInfo' was signed by a trusted source
-	err = ctx.verifySignedInfo(sig, signatureMethodAlgorithmAttr.Value, cert, decodedSignature)
+	err = ctx.verifySignedInfo(sig, c14nAlgorithmId, signatureMethodAlgorithmAttr.Value, cert, decodedSignature)
 	if err != nil {
 		return nil, err
 	}

--- a/validate.go
+++ b/validate.go
@@ -105,8 +105,13 @@ func (ctx *ValidationContext) transform(root, sig *etree.Element, transforms []*
 }
 
 func (ctx *ValidationContext) digest(el *etree.Element, digestAlgorithmId, c14nAlgorithmId string) ([]byte, error) {
+	canonical, err := canonicalize(el, AlgorithmID(c14nAlgorithmId))
+	if err != nil {
+		return nil, err
+	}
+
 	doc := etree.NewDocument()
-	doc.SetRoot(canonicalize(el, AlgorithmID(c14nAlgorithmId)))
+	doc.SetRoot(canonical)
 
 	doc.WriteSettings = etree.WriteSettings{
 		CanonicalAttrVal: true,
@@ -120,7 +125,7 @@ func (ctx *ValidationContext) digest(el *etree.Element, digestAlgorithmId, c14nA
 	}
 
 	hash := digestAlgorithm.New()
-	_, err := doc.WriteTo(hash)
+	_, err = doc.WriteTo(hash)
 	if err != nil {
 		return nil, err
 	}
@@ -140,8 +145,13 @@ func (ctx *ValidationContext) verifySignedInfo(signatureElement *etree.Element, 
 	}
 
 	// Canonicalize the xml
+	canonical, err := canonicalize(signedInfo, AlgorithmID(c14nAlgorithmId))
+	if err != nil {
+		return err
+	}
+
 	doc := etree.NewDocument()
-	doc.SetRoot(canonicalize(signedInfo, AlgorithmID(c14nAlgorithmId)))
+	doc.SetRoot(canonical)
 	doc.WriteSettings = etree.WriteSettings{
 		CanonicalAttrVal: true,
 		CanonicalEndTags: true,
@@ -154,7 +164,7 @@ func (ctx *ValidationContext) verifySignedInfo(signatureElement *etree.Element, 
 	}
 
 	hash := signatureAlgorithm.New()
-	_, err := doc.WriteTo(hash)
+	_, err = doc.WriteTo(hash)
 	if err != nil {
 		return err
 	}

--- a/validate.go
+++ b/validate.go
@@ -85,12 +85,12 @@ func (ctx *ValidationContext) transform(root, sig *etree.Element, transforms []*
 			return nil, "", errors.New("Missing Algorithm attribute")
 		}
 
-		switch algo.Value {
+		switch AlgorithmID(algo.Value) {
 		case EnvelopedSignatureAltorithmId:
 			if !recursivelyRemoveElement(root, sig) {
 				return nil, "", errors.New("Error applying canonicalization transform: Signature not found")
 			}
-		case string(CanonicalXML10AlgorithmId), string(CanonicalXML11AlgorithmId):
+		case CanonicalXML10ExclusiveAlgorithmId, CanonicalXML11AlgorithmId:
 			c14nAlgorithm = algo.Value
 		default:
 			return nil, "", errors.New("Unknown Transform Algorithm: " + algo.Value)
@@ -106,7 +106,7 @@ func (ctx *ValidationContext) transform(root, sig *etree.Element, transforms []*
 
 func (ctx *ValidationContext) digest(el *etree.Element, digestAlgorithmId, c14nAlgorithmId string) ([]byte, error) {
 	doc := etree.NewDocument()
-	doc.SetRoot(canonicalize(el, SignatureAlgorithm(c14nAlgorithmId)))
+	doc.SetRoot(canonicalize(el, AlgorithmID(c14nAlgorithmId)))
 
 	doc.WriteSettings = etree.WriteSettings{
 		CanonicalAttrVal: true,
@@ -141,7 +141,7 @@ func (ctx *ValidationContext) verifySignedInfo(signatureElement *etree.Element, 
 
 	// Canonicalize the xml
 	doc := etree.NewDocument()
-	doc.SetRoot(canonicalize(signedInfo, SignatureAlgorithm(signatureMethodId)))
+	doc.SetRoot(canonicalize(signedInfo, AlgorithmID(signatureMethod)))
 	doc.WriteSettings = etree.WriteSettings{
 		CanonicalAttrVal: true,
 		CanonicalEndTags: true,

--- a/xml_constants.go
+++ b/xml_constants.go
@@ -30,16 +30,19 @@ const (
 	DefaultIdAttr = "ID"
 )
 
-type SignatureAlgorithm string
+type AlgorithmID string
+
+func (id AlgorithmID) String() string {
+	return string(id)
+}
 
 //Well-known signature algorithms
 const (
-	// NOTE(russell_h): I guess 1.0 is "exclusive" and 1.1 isn't
-	CanonicalXML10AlgorithmId SignatureAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#"
-	CanonicalXML11AlgorithmId                    = "http://www.w3.org/2006/12/xml-c14n11"
-)
-const (
-	EnvelopedSignatureAltorithmId = "http://www.w3.org/2000/09/xmldsig#enveloped-signature"
+	// Supported canonicalization algorithms
+	CanonicalXML10ExclusiveAlgorithmId AlgorithmID = "http://www.w3.org/2001/10/xml-exc-c14n#"
+	CanonicalXML11AlgorithmId          AlgorithmID = "http://www.w3.org/2006/12/xml-c14n11"
+
+	EnvelopedSignatureAltorithmId AlgorithmID = "http://www.w3.org/2000/09/xmldsig#enveloped-signature"
 )
 
 var digestAlgorithmIdentifiers = map[crypto.Hash]string{


### PR DESCRIPTION
I noticed that the `canonicalize()` function was getting algorithm identifiers like `http://www.w3.org/2001/04/xmldsig-more#rsa-sha256`. It turns out that in one location we were passing the signature algorithm instead of the canonicalization algorithm.

This PR:

1. Fixes that bug, passing the c14n algorithm instead of the signing one
2. Improves the typing and variable naming of algorithm identifiers
3. Makes the switch statement in `canonicalize` explicitly check each algorithm identifier, with the default case returning an error