### PR TITLE
Support "InclusiveNamespaces PrefixList" in Exclusive Canonicalization

### DIFF
--- a/canonicalize.go
+++ b/canonicalize.go
@@ -1,13 +1,63 @@
 package dsig
 
 import (
-	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/beevik/etree"
 )
 
-type attrsByKey []etree.Attr
+// Canonicalizer is an implementation of a canonicalization algorithm.
+type Canonicalizer interface {
+	Canonicalize(el *etree.Element) ([]byte, error)
+	Algorithm() AlgorithmID
+}
+
+type c14N10ExclusiveCanonicalizer struct {
+	InclusiveNamespaces map[string]struct{}
+}
+
+// MakeC14N10ExclusiveCanonicalizerWithPrefixList constructs an exclusive Canonicalizer
+// from a PrefixList in NMTOKENS format (a white space separated list).
+func MakeC14N10ExclusiveCanonicalizerWithPrefixList(prefixList string) Canonicalizer {
+	prefixes := strings.Fields(prefixList)
+	prefixSet := make(map[string]struct{}, len(prefixList))
+
+	for _, prefix := range prefixes {
+		prefixSet[prefix] = struct{}{}
+	}
+
+	return &c14N10ExclusiveCanonicalizer{
+		InclusiveNamespaces: prefixSet,
+	}
+}
+
+// Canonicalize transforms the input Element into a serialized XML document in canonical form.
+func (c *c14N10ExclusiveCanonicalizer) Canonicalize(el *etree.Element) ([]byte, error) {
+	scope := make(map[string]c14nSpace)
+	return canonicalSerialize(excCanonicalPrep(el, scope, c.InclusiveNamespaces))
+}
+
+func (c *c14N10ExclusiveCanonicalizer) Algorithm() AlgorithmID {
+	return CanonicalXML10ExclusiveAlgorithmId
+}
+
+type c14N11Canonicalizer struct{}
+
+// MakeC14N11Canonicalizer constructs an inclusive canonicalizer.
+func MakeC14N11Canonicalizer() Canonicalizer {
+	return &c14N11Canonicalizer{}
+}
+
+// Canonicalize transforms the input Element into a serialized XML document in canonical form.
+func (c *c14N11Canonicalizer) Canonicalize(el *etree.Element) ([]byte, error) {
+	scope := make(map[string]struct{})
+	return canonicalSerialize(canonicalPrep(el, scope))
+}
+
+func (c *c14N11Canonicalizer) Algorithm() AlgorithmID {
+	return CanonicalXML11AlgorithmId
+}
 
 func composeAttr(space, key string) string {
 	if space != "" {
@@ -16,6 +66,8 @@ func composeAttr(space, key string) string {
 
 	return key
 }
+
+type attrsByKey []etree.Attr
 
 func (a attrsByKey) Len() int {
 	return len(a)
@@ -47,52 +99,6 @@ func (a attrsByKey) Less(i, j int) bool {
 	return composeAttr(a[i].Space, a[i].Key) < composeAttr(a[j].Space, a[j].Key)
 }
 
-func _canonicalHack(el *etree.Element, seenSoFar map[string]struct{}) *etree.Element {
-	_seenSoFar := make(map[string]struct{})
-	for k, v := range seenSoFar {
-		_seenSoFar[k] = v
-	}
-
-	ne := el.Copy()
-	sort.Sort(attrsByKey(ne.Attr))
-	if len(ne.Attr) != 0 {
-		for _, attr := range ne.Attr {
-			if attr.Space != "xmlns" {
-				continue
-			}
-			key := attr.Space + ":" + attr.Key
-			if _, seen := _seenSoFar[key]; seen {
-				ne.RemoveAttr(attr.Space + ":" + attr.Key)
-			} else {
-				_seenSoFar[key] = struct{}{}
-			}
-		}
-	}
-
-	for i, token := range ne.Child {
-		childElement, ok := token.(*etree.Element)
-		if ok {
-			ne.Child[i] = _canonicalHack(childElement, _seenSoFar)
-		}
-	}
-
-	return ne
-}
-
-// NOTE(russell_h): It looks like etree's canonical XML support doesn't
-// re-order attributes. This call is an opportunity to do that, and correct
-// any other other shortcomings until I can get the fixes upstream.
-// NOTE(phoebe): Looks like etree also doesn't remove attributes that are
-// duplicate namespaces. They should be removed if a parent has a matching one
-func canonicalHack(el *etree.Element) *etree.Element {
-	attrMap := make(map[string]struct{})
-	return _canonicalHack(el, attrMap)
-}
-
-func getNsDecl(a etree.Attr) string {
-	return fmt.Sprintf("xmlns:%s", a.Key)
-}
-
 type c14nSpace struct {
 	a    etree.Attr
 	used bool
@@ -100,7 +106,16 @@ type c14nSpace struct {
 
 const nsSpace = "xmlns"
 
-func _excCanonicalPrep(el *etree.Element, _nsAlreadyDeclared map[string]c14nSpace) *etree.Element {
+// excCanonicalPrep accepts an *etree.Element and recursively transforms it into one
+// which is ready for serialization to exclusive canonical form. Specifically this
+// entails:
+//
+// 1. Stripping re-declarations of namespaces
+// 2. Stripping unused namespaces
+// 3. Sorting attributes into canonical order.
+//
+// NOTE(russell_h): Currently this function modifies the passed element.
+func excCanonicalPrep(el *etree.Element, _nsAlreadyDeclared map[string]c14nSpace, inclusiveNamespaces map[string]struct{}) *etree.Element {
 	//Copy alreadyDeclared map (only contains namespaces)
 	nsAlreadyDeclared := make(map[string]c14nSpace, len(_nsAlreadyDeclared))
 	for k := range _nsAlreadyDeclared {
@@ -121,6 +136,7 @@ func _excCanonicalPrep(el *etree.Element, _nsAlreadyDeclared map[string]c14nSpac
 	for _, a := range el.Attr {
 		switch a.Space {
 		case nsSpace:
+
 			//For simplicity, remove all xmlns attribues; to be added in one pass
 			//later.  Otherwise, we need another map/set to track xmlns attributes
 			//that we left alone.
@@ -130,6 +146,16 @@ func _excCanonicalPrep(el *etree.Element, _nsAlreadyDeclared map[string]c14nSpac
 				//it to the map
 				nsAlreadyDeclared[a.Key] = c14nSpace{a: a, used: false}
 			}
+
+			// This algorithm accepts a set of namespaces which should be treated
+			// in an inclusive fashion. Specifically that means we should keep the
+			// declaration of that namespace closest to the root of the tree. We can
+			// accomplish that be pretending it was used by this element.
+			_, inclusive := inclusiveNamespaces[a.Key]
+			if inclusive {
+				nsUsedHere[a.Key] = struct{}{}
+			}
+
 		default:
 			//We only track namespaces, so ignore attributes without one.
 			if a.Space != "" {
@@ -137,6 +163,7 @@ func _excCanonicalPrep(el *etree.Element, _nsAlreadyDeclared map[string]c14nSpac
 			}
 		}
 	}
+
 	//Remove all attributes so that we can add them with much-simpler logic
 	for _, attrK := range toRemove {
 		el.RemoveAttr(attrK)
@@ -158,7 +185,7 @@ func _excCanonicalPrep(el *etree.Element, _nsAlreadyDeclared map[string]c14nSpac
 
 	//Canonicalize all children, passing down the ancestor tracking map
 	for _, child := range el.ChildElements() {
-		_excCanonicalPrep(child, nsAlreadyDeclared)
+		excCanonicalPrep(child, nsAlreadyDeclared, inclusiveNamespaces)
 	}
 
 	//Sort attributes lexicographically
@@ -167,19 +194,58 @@ func _excCanonicalPrep(el *etree.Element, _nsAlreadyDeclared map[string]c14nSpac
 	return el.Copy()
 }
 
-func excCanonicalPrep(el *etree.Element) *etree.Element {
-	return _excCanonicalPrep(el, make(map[string]c14nSpace))
+// canonicalPrep accepts an *etree.Element and transforms it into one which is ready
+// for serialization into inclusive canonical form. Specifically this
+// entails:
+//
+// 1. Stripping re-declarations of namespaces
+// 2. Sorting attributes into canonical order
+//
+// Inclusive canonicalization does not strip unused namespaces.
+//
+// TODO(russell_h): This is very similar to excCanonicalPrep - perhaps they should
+// be unified into one parameterized function?
+func canonicalPrep(el *etree.Element, seenSoFar map[string]struct{}) *etree.Element {
+	_seenSoFar := make(map[string]struct{})
+	for k, v := range seenSoFar {
+		_seenSoFar[k] = v
+	}
+
+	ne := el.Copy()
+	sort.Sort(attrsByKey(ne.Attr))
+	if len(ne.Attr) != 0 {
+		for _, attr := range ne.Attr {
+			if attr.Space != nsSpace {
+				continue
+			}
+			key := attr.Space + ":" + attr.Key
+			if _, seen := _seenSoFar[key]; seen {
+				ne.RemoveAttr(attr.Space + ":" + attr.Key)
+			} else {
+				_seenSoFar[key] = struct{}{}
+			}
+		}
+	}
+
+	for i, token := range ne.Child {
+		childElement, ok := token.(*etree.Element)
+		if ok {
+			ne.Child[i] = canonicalPrep(childElement, _seenSoFar)
+		}
+	}
+
+	return ne
 }
 
-func canonicalize(el *etree.Element, canonicalizationMethod AlgorithmID) (*etree.Element, error) {
-	switch canonicalizationMethod {
-	case CanonicalXML10ExclusiveAlgorithmId:
-		return excCanonicalPrep(el), nil
+func canonicalSerialize(el *etree.Element) ([]byte, error) {
+	doc := etree.NewDocument()
+	doc.SetRoot(el)
 
-	case CanonicalXML11AlgorithmId:
-		return canonicalHack(el), nil
-
-	default:
-		return nil, fmt.Errorf("unknown canonicalization algorithm: %s", canonicalizationMethod.String())
+	doc.WriteSettings = etree.WriteSettings{
+		CanonicalAttrVal: true,
+		CanonicalEndTags: true,
+		CanonicalText:    true,
 	}
+
+	return doc.WriteToBytes()
 }

--- a/canonicalize.go
+++ b/canonicalize.go
@@ -21,7 +21,7 @@ type c14N10ExclusiveCanonicalizer struct {
 // from a PrefixList in NMTOKENS format (a white space separated list).
 func MakeC14N10ExclusiveCanonicalizerWithPrefixList(prefixList string) Canonicalizer {
 	prefixes := strings.Fields(prefixList)
-	prefixSet := make(map[string]struct{}, len(prefixList))
+	prefixSet := make(map[string]struct{}, len(prefixes))
 
 	for _, prefix := range prefixes {
 		prefixSet[prefix] = struct{}{}

--- a/canonicalize_test.go
+++ b/canonicalize_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/beevik/etree"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -13,57 +14,23 @@ const (
 )
 
 func TestExcC14N10(t *testing.T) {
-	raw := etree.NewDocument()
+	canonicalizer := MakeC14N10ExclusiveCanonicalizerWithPrefixList("")
 
+	raw := etree.NewDocument()
 	raw.ReadFromString(assertion)
 
-	hacked := excCanonicalPrep(raw.Root())
-
-	hd := etree.NewDocument()
-
-	hd.SetRoot(hacked)
-
-	hd.WriteSettings = etree.WriteSettings{
-		CanonicalAttrVal: true,
-		CanonicalEndTags: true,
-	}
-
-	hs, err := hd.WriteToString()
-	if err != nil {
-		t.Fatalf("could not write c14n doc: %v", err)
-	}
-
-	if hs != assertionC14ned {
-		t.Log(hs)
-		t.Log(assertionC14ned)
-		t.Errorf("Wrong canonical representation.")
-	}
+	canonicalized, err := canonicalizer.Canonicalize(raw.Root())
+	require.NoError(t, err)
+	require.Equal(t, assertionC14ned, string(canonicalized))
 }
 
 func TestC14N11(t *testing.T) {
-	raw := etree.NewDocument()
+	canonicalizer := MakeC14N11Canonicalizer()
 
+	raw := etree.NewDocument()
 	raw.ReadFromString(assertion)
 
-	hacked := canonicalHack(raw.Root())
-
-	hd := etree.NewDocument()
-
-	hd.SetRoot(hacked)
-
-	hd.WriteSettings = etree.WriteSettings{
-		CanonicalAttrVal: true,
-		CanonicalEndTags: true,
-	}
-
-	hs, err := hd.WriteToString()
-	if err != nil {
-		t.Fatalf("could not write c14n doc: %v", err)
-	}
-
-	if hs != c14n11 {
-		t.Log(hs)
-		t.Log(c14n11)
-		t.Errorf("Wrong canonical representation.")
-	}
+	canonicalized, err := canonicalizer.Canonicalize(raw.Root())
+	require.NoError(t, err)
+	require.Equal(t, c14n11, string(canonicalized))
 }

--- a/validate.go
+++ b/validate.go
@@ -97,9 +97,9 @@ func (ctx *ValidationContext) transform(root, sig *etree.Element, transforms []*
 
 		case CanonicalXML10ExclusiveAlgorithmId:
 			var prefixList string
-			ins := transform.FindElement(childPath("", "InclusiveNamespaces"))
+			ins := transform.FindElement(childPath("", InclusiveNamespacesTag))
 			if ins != nil {
-				prefixListEl := ins.SelectAttr("PrefixList")
+				prefixListEl := ins.SelectAttr(PrefixListAttr)
 				if prefixListEl != nil {
 					prefixList = prefixListEl.Value
 				}

--- a/xml_constants.go
+++ b/xml_constants.go
@@ -22,12 +22,14 @@ const (
 	KeyInfoTag                = "KeyInfo"
 	X509DataTag               = "X509Data"
 	X509CertificateTag        = "X509Certificate"
+	InclusiveNamespacesTag    = "InclusiveNamespaces"
 )
 
 const (
-	AlgorithmAttr = "Algorithm"
-	URIAttr       = "URI"
-	DefaultIdAttr = "ID"
+	AlgorithmAttr  = "Algorithm"
+	URIAttr        = "URI"
+	DefaultIdAttr  = "ID"
+	PrefixListAttr = "PrefixList"
 )
 
 type AlgorithmID string


### PR DESCRIPTION
This is based off of #11 

It turns out exclusive canonicalization is meant to take a list of namespace prefixes which should be treated in an inclusive fashion as a parameter.

In order to better support parameterizing canonicalization, I introduced a new `Canonicalizer` interface, with inclusive and exclusive implementations, each of which is mostly a wrapper around our existing canonicalization functions.

I also renamed `canonicalHack` to `canonicalPrep` to clarify their relationship to `excCanonicalPrep`. I was able to remove the underscore prefixed versions of each by moving initialization of the recursion into the respective `Canonicalizer` implementations.

Finally I added support to `excCanonicalPrep` for accepting a list of namespace prefixes to treat in an inclusive fashion. With this change gosaml2 now supports Okta (again - we accidentally supported it before with our inclusive canonicalization, before we discriminated between canonicalization methods correctly).