### PR TITLE
Improve Order of Namespace Declarations and Attributes in Canonical XML

### DIFF
--- a/canonicalize.go
+++ b/canonicalize.go
@@ -84,6 +84,9 @@ func (a attrsByKey) Less(i, j int) bool {
 	if a[i].Space == "" && a[i].Key == "xmlns" {
 		return true
 	}
+	if a[j].Space == "" && a[j].Key == "xmlns" {
+		return false
+	}
 
 	if a[i].Space == "xmlns" {
 		if a[j].Space == "xmlns" {


### PR DESCRIPTION
The sorting of xml attributes and namespace declarations is not always correct, because in function [`Less(i, j int) bool`](https://github.com/russellhaering/goxmldsig/blob/master/canonicalize.go#L80-L86) the case when the attribute with index `j` is a `xmlns` attribute has been forgotten. In this case the `xmlns` attribute has been handled as a normal attribute.