### PR TITLE
be forgiving of whitespace in cert, added go test driver

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+cd `dirname $0`
+DIRS=`git grep -l 'func Test' | xargs dirname | sort -u`
+for DIR in $DIRS
+do
+	echo
+	echo "dir: $DIR"
+	echo "======================================"
+	pushd $DIR >/dev/null
+	go test -v || exit 1
+	popd >/dev/null
+done

--- a/validate.go
+++ b/validate.go
@@ -15,6 +15,7 @@ import (
 )
 
 var uriRegexp = regexp.MustCompile("^#[a-zA-Z_][\\w.-]*$")
+var whiteSpace = regexp.MustCompile("\\s+")
 
 var (
 	// ErrMissingSignature indicates that no enveloped signature was found referencing
@@ -367,7 +368,8 @@ func (ctx *ValidationContext) verifyCertificate(sig *types.Signature) (*x509.Cer
 			return nil, errors.New("missing X509Certificate within KeyInfo")
 		}
 
-		certData, err := base64.StdEncoding.DecodeString(sig.KeyInfo.X509Data.X509Certificate.Data)
+		certData, err := base64.StdEncoding.DecodeString(
+			whiteSpace.ReplaceAllString(sig.KeyInfo.X509Data.X509Certificate.Data, ""))
 		if err != nil {
 			return nil, errors.New("Failed to parse certificate")
 		}


### PR DESCRIPTION
* run_test.sh: runs go test in all dirs with .go with 'func Test'
* strip whitespace when reading cert base64 out of Response
  * ```base64.StdEncoding.DecodeString()``` ok with newlines, but not spaces


