### PR TITLE
Support x509 certificate chains in encode and decode

### DIFF
--- a/keystore.go
+++ b/keystore.go
@@ -12,6 +12,10 @@ type X509KeyStore interface {
 	GetKeyPair() (privateKey *rsa.PrivateKey, cert []byte, err error)
 }
 
+type X509ChainStore interface {
+	GetChain() (certs [][]byte, err error)
+}
+
 type X509CertificateStore interface {
 	Certificates() (roots []*x509.Certificate, err error)
 }

--- a/tls_keystore.go
+++ b/tls_keystore.go
@@ -32,3 +32,8 @@ func (d TLSCertKeyStore) GetKeyPair() (*rsa.PrivateKey, []byte, error) {
 
 	return pk, crt, nil
 }
+
+//GetChain impliments X509ChainStore using the underlying tls.Certificate
+func (d TLSCertKeyStore) GetChain() ([][]byte, error) {
+	return d.Certificate, nil
+}

--- a/types/signature.go
+++ b/types/signature.go
@@ -63,8 +63,8 @@ type KeyInfo struct {
 }
 
 type X509Data struct {
-	XMLName         xml.Name        `xml:"http://www.w3.org/2000/09/xmldsig# X509Data"`
-	X509Certificate X509Certificate `xml:"X509Certificate"`
+	XMLName          xml.Name          `xml:"http://www.w3.org/2000/09/xmldsig# X509Data"`
+	X509Certificates []X509Certificate `xml:"X509Certificate"`
 }
 
 type X509Certificate struct {

--- a/validate.go
+++ b/validate.go
@@ -364,12 +364,12 @@ func (ctx *ValidationContext) verifyCertificate(sig *types.Signature) (*x509.Cer
 
 	if sig.KeyInfo != nil {
 		// If the Signature includes KeyInfo, extract the certificate from there
-		if sig.KeyInfo.X509Data.X509Certificate.Data == "" {
+		if len(sig.KeyInfo.X509Data.X509Certificates) == 0 || sig.KeyInfo.X509Data.X509Certificates[0].Data == "" {
 			return nil, errors.New("missing X509Certificate within KeyInfo")
 		}
 
 		certData, err := base64.StdEncoding.DecodeString(
-			whiteSpace.ReplaceAllString(sig.KeyInfo.X509Data.X509Certificate.Data, ""))
+			whiteSpace.ReplaceAllString(sig.KeyInfo.X509Data.X509Certificates[0].Data, ""))
 		if err != nil {
 			return nil, errors.New("Failed to parse certificate")
 		}


### PR DESCRIPTION
The X509Data element can contain a full chain of certificates. This adds support for encoding and decoding the chain. It does not modify the validation code, which continues to compare leaf nodes.

https://www.w3.org/TR/xmldsig-core/#sec-X509Data