### PR TITLE
Handle when IDP does not use namespace prefix on CanonicalizationMethod

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -286,6 +286,7 @@ func (ctx *ValidationContext) findSignature(el *etree.Element) (*types.Signature
 
 				c14NMethod := detachedSignedInfo.FindElement(childPath(detachedSignedInfo.Space, CanonicalizationMethodTag))
 				if c14NMethod == nil {
+					c14NMethod = detachedSignedInfo.FindElement(childPath("", CanonicalizationMethodTag))
 					return errors.New("missing CanonicalizationMethod on Signature")
 				}
 

--- a/validate.go
+++ b/validate.go
@@ -287,7 +287,9 @@ func (ctx *ValidationContext) findSignature(el *etree.Element) (*types.Signature
 				c14NMethod := detachedSignedInfo.FindElement(childPath(detachedSignedInfo.Space, CanonicalizationMethodTag))
 				if c14NMethod == nil {
 					c14NMethod = detachedSignedInfo.FindElement(childPath("", CanonicalizationMethodTag))
-					return errors.New("missing CanonicalizationMethod on Signature")
+					if c14NMethod == nil {
+						return errors.New("missing CanonicalizationMethod on Signature")
+					}
 				}
 
 				c14NAlgorithm := c14NMethod.SelectAttrValue(AlgorithmAttr, "")


### PR DESCRIPTION
The "Novell Access Manager" does not put a namespace prefix on the CanonicalizationMethod element. (or at least the installed version we are working with does not). We _tried_ to write a test. This is a minimalist change rather than changing `childPath`.

In fact the official documentation shows that the namespace prefix is not applied to CanonicalizationMethod.
https://www.netiq.com/documentation/access-manager-43/admin/data/b65ogn0.html
`<ds:SignedInfo>
				<CanonicalizationMethod xmlns="http://www.w3.org/2000/09/xmldsig#" Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
				<ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
        <ds:Reference URI="#idF5JceWGWYwS3bOkmJS2wJuNqitU">
					<ds:Transforms>
            <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
            <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
          </ds:Transforms>
          <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
          <DigestValue xmlns="http://www.w3.org/2000/09/xmldsig#">ZocFiEUYcda0cKGRNcZYZqvmnlM=</DigestValue>
        </ds:Reference>
      </ds:SignedInfo>`