### PR TITLE
Support http://www.w3.org/2001/10/xml-exc-c14n#WithComments

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -141,6 +141,14 @@ func (ctx *ValidationContext) transform(
 
 			canonicalizer = MakeC14N10ExclusiveCanonicalizerWithPrefixList(prefixList)
 
+		case CanonicalXML10ExclusiveCommentAlgorithmId:
+			var prefixList string
+			if transform.InclusiveNamespaces != nil {
+				prefixList = transform.InclusiveNamespaces.PrefixList
+			}
+
+			canonicalizer = MakeC14N10ExclusiveCanonicalizerWithPrefixList(prefixList)
+
 		case CanonicalXML11AlgorithmId:
 			canonicalizer = MakeC14N11Canonicalizer()
 

--- a/xml_constants.go
+++ b/xml_constants.go
@@ -47,8 +47,9 @@ const (
 //Well-known signature algorithms
 const (
 	// Supported canonicalization algorithms
-	CanonicalXML10ExclusiveAlgorithmId AlgorithmID = "http://www.w3.org/2001/10/xml-exc-c14n#"
-	CanonicalXML11AlgorithmId          AlgorithmID = "http://www.w3.org/2006/12/xml-c14n11"
+	CanonicalXML10ExclusiveAlgorithmId        AlgorithmID = "http://www.w3.org/2001/10/xml-exc-c14n#"
+	CanonicalXML10ExclusiveCommentAlgorithmId AlgorithmID = "http://www.w3.org/2001/10/xml-exc-c14n#WithComments"
+	CanonicalXML11AlgorithmId                 AlgorithmID = "http://www.w3.org/2006/12/xml-c14n11"
 
 	CanonicalXML10RecAlgorithmId     AlgorithmID = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315"
 	CanonicalXML10CommentAlgorithmId AlgorithmID = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments"


### PR DESCRIPTION
Support for

Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#WithComments"

Is now able to verify this:
    
    <ds:Transforms>
      <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
      <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#WithComments"/>
    </ds:Transforms>
    ....