### PR TITLE
support empty reference URI for enveloped signature

### DIFF
--- a/sign.go
+++ b/sign.go
@@ -92,11 +92,11 @@ func (ctx *SigningContext) constructSignedInfo(el *etree.Element, enveloped bool
 
 	dataId := el.SelectAttrValue(ctx.IdAttribute, "")
 	if dataId == "" {
-		return nil, errors.New("Missing data ID")
+		reference.CreateAttr(URIAttr, "")
 	}
-
-	reference.CreateAttr(URIAttr, "#"+dataId)
-
+	if dataId != "" {
+		reference.CreateAttr(URIAttr, "#"+dataId)
+	}
 	// /SignedInfo/Reference/Transforms
 	transforms := ctx.createNamespacedElement(reference, TransformsTag)
 	if enveloped {


### PR DESCRIPTION
Signed XML is verified by my partner and they require empty URI or signature verification fails. The structure is strict and I can't even add the ID attribute.

https://www.w3.org/TR/xmldsig-core/#sec-URI says

> If the URI attribute is omitted altogether, the receiving application is expected to know the identity of the object.

I think we should allow empty URI for enveloped signature.