### PR TITLE
Allow ID attribute as an option in XML file

### DIFF
--- a/sign.go
+++ b/sign.go
@@ -90,12 +90,14 @@ func (ctx *SigningContext) constructSignedInfo(el *etree.Element, enveloped bool
 	// /SignedInfo/Reference
 	reference := ctx.createNamespacedElement(signedInfo, ReferenceTag)
 
-	dataId := el.SelectAttrValue(ctx.IdAttribute, "")
-	if dataId == "" {
-		return nil, errors.New("Missing data ID")
-	}
+	// dataId := el.SelectAttrValue(ctx.IdAttribute, "")
+	// if dataId == "" {
+	// 	return nil, errors.New("Missing data ID")
+	// }
 
-	reference.CreateAttr(URIAttr, "#"+dataId)
+	// reference.CreateAttr(URIAttr, "#"+dataId)
+
+	reference.CreateAttr(URIAttr, "")
 
 	// /SignedInfo/Reference/Transforms
 	transforms := ctx.createNamespacedElement(reference, TransformsTag)

--- a/sign.go
+++ b/sign.go
@@ -90,14 +90,13 @@ func (ctx *SigningContext) constructSignedInfo(el *etree.Element, enveloped bool
 	// /SignedInfo/Reference
 	reference := ctx.createNamespacedElement(signedInfo, ReferenceTag)
 
-	// dataId := el.SelectAttrValue(ctx.IdAttribute, "")
-	// if dataId == "" {
-	// 	return nil, errors.New("Missing data ID")
-	// }
+	dataId := el.SelectAttrValue(ctx.IdAttribute, "")
 
-	// reference.CreateAttr(URIAttr, "#"+dataId)
-
-	reference.CreateAttr(URIAttr, "")
+	if dataId == "" {
+		reference.CreateAttr(URIAttr, "")
+	} else {
+		reference.CreateAttr(URIAttr, "#"+dataId)
+	}
 
 	// /SignedInfo/Reference/Transforms
 	transforms := ctx.createNamespacedElement(reference, TransformsTag)

--- a/sign_test.go
+++ b/sign_test.go
@@ -80,7 +80,7 @@ func TestSign(t *testing.T) {
 	require.Equal(t, base64.StdEncoding.EncodeToString(digest), digestValueElement.Text())
 }
 
-func TestSignErrors(t *testing.T) {
+func TestSignNoIDAttribute(t *testing.T) {
 	randomKeyStore := RandomKeyStoreForTest()
 	ctx := &SigningContext{
 		Hash:        crypto.SHA512_256,
@@ -105,8 +105,13 @@ func TestSignErrors(t *testing.T) {
 		Tag:   "AuthnRequest",
 	}
 
-	_, err = ctx.SignEnveloped(authnRequest)
-	require.Error(t, err)
+	signed, err := ctx.SignEnveloped(authnRequest)
+	require.NoError(t, err)
+
+	ref := signed.FindElement("./Signature/SignedInfo/Reference")
+	require.NotNil(t, ref)
+	refURI := ref.SelectAttrValue("URI", "")
+	require.Equal(t, refURI, "")
 }
 
 func TestSignNonDefaultID(t *testing.T) {


### PR DESCRIPTION
Description of the change: This pull request allows ID attribute becoming an option in XML file. If the XML has an ID, the package will sign the element using the specified ID (same behavior). If the XML doesn't has an ID attribute, the package will sign entire XML file and set the URIAttr to empty string. 

Reason: This way of implementation is currently used in .NET package System.Security.Cryptography.Xml. This change would benefit to whoever needs to work on projects which spans to multiple platform. The change doesn't change existing behavior of the package and only add the flexibility to the package. 