### PR TITLE
Fix canonicalization

### DIFF
--- a/canonicalize.go
+++ b/canonicalize.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 
 	"github.com/beevik/etree"
-	"github.com/russellhaering/goxmldsig/etreeutils"
+	"github.com/pboyd04/goxmldsig/etreeutils"
 )
 
 // Canonicalizer is an implementation of a canonicalization algorithm.

--- a/etreeutils/canonicalize.go
+++ b/etreeutils/canonicalize.go
@@ -40,9 +40,10 @@ func transformExcC14n(ctx, declared NSContext, el *etree.Element, inclusiveNames
 	for _, attr := range el.Attr {
 		switch {
 		case attr.Space == xmlnsPrefix:
-			if _, ok := inclusiveNamespaces[attr.Key]; ok {
-				visiblyUtilizedPrefixes[attr.Key] = struct{}{}
-			}
+			//This probably isn't the right way to fix this, but if a namespace is unused the reference implementation leaves it alone
+			//if _, ok := inclusiveNamespaces[attr.Key]; ok {
+			visiblyUtilizedPrefixes[attr.Key] = struct{}{}
+			//}
 
 		case attr.Space == defaultPrefix && attr.Key == xmlnsPrefix:
 			if _, ok := inclusiveNamespaces[defaultPrefix]; ok {


### PR DESCRIPTION
If you have an unused namespace at the root level currently it is eliminated by canonicalization, however libxml2/libxmlsec leave them alone. 