### PR TITLE
Explicitly check for case where SignatureValue is nil

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -268,6 +268,9 @@ func (ctx *ValidationContext) validateSignature(el *etree.Element, sig *types.Si
 	if !bytes.Equal(digest, decodedDigestValue) {
 		return nil, errors.New("Signature could not be verified")
 	}
+	if sig.SignatureValue == nil {
+		return nil, errors.New("Signature could not be verified")
+	}
 
 	// Decode the 'SignatureValue' so we can compare against it
 	decodedSignature, err := base64.StdEncoding.DecodeString(sig.SignatureValue.Data)


### PR DESCRIPTION
Check for the case where SignatureValue is nil in order to explicitly prevent the case reported in https://github.com/russellhaering/goxmldsig/issues/48 and get the CVE closed which is currently preventing those with 'vulnerable dependancy' checks from using the library.

fixes #48 