### PR TITLE
Support for http://www.w3.org/2001/10/xml-exc-c14n\#WithComments

### DIFF
--- a/canonicalize.go
+++ b/canonicalize.go
@@ -106,6 +106,23 @@ func (c *c14N10CommentCanonicalizer) Algorithm() AlgorithmID {
 	return CanonicalXML10CommentAlgorithmId
 }
 
+type CanonicalXML10ExclusiveComment struct{}
+
+// MakeCanonicalXML10ExclusiveComment constructs an inclusive canonicalizer.
+func MakeCanonicalXML10ExclusiveComment() Canonicalizer {
+	return &CanonicalXML10ExclusiveComment{}
+}
+
+// Canonicalize transforms the input Element into a serialized XML document in canonical form.
+func (c *CanonicalXML10ExclusiveComment) Canonicalize(el *etree.Element) ([]byte, error) {
+	scope := make(map[string]struct{})
+	return canonicalSerialize(canonicalPrep(el, scope, true))
+}
+
+func (c *CanonicalXML10ExclusiveComment) Algorithm() AlgorithmID {
+	return CanonicalXML10ExclusiveCommentAlgorithmId
+}
+
 func composeAttr(space, key string) string {
 	if space != "" {
 		return space + ":" + key

--- a/canonicalize.go
+++ b/canonicalize.go
@@ -108,7 +108,7 @@ func (c *c14N10CommentCanonicalizer) Algorithm() AlgorithmID {
 
 type CanonicalXML10ExclusiveComment struct{}
 
-// MakeCanonicalXML10ExclusiveComment constructs an canonicalizer.
+// MakeCanonicalXML10ExclusiveComment constructs a canonicalizer.
 func MakeCanonicalXML10ExclusiveComment() Canonicalizer {
 	return &CanonicalXML10ExclusiveComment{}
 }

--- a/canonicalize.go
+++ b/canonicalize.go
@@ -108,7 +108,7 @@ func (c *c14N10CommentCanonicalizer) Algorithm() AlgorithmID {
 
 type CanonicalXML10ExclusiveComment struct{}
 
-// MakeCanonicalXML10ExclusiveComment constructs an inclusive canonicalizer.
+// MakeCanonicalXML10ExclusiveComment constructs an canonicalizer.
 func MakeCanonicalXML10ExclusiveComment() Canonicalizer {
 	return &CanonicalXML10ExclusiveComment{}
 }

--- a/validate.go
+++ b/validate.go
@@ -141,6 +141,14 @@ func (ctx *ValidationContext) transform(
 		case CanonicalXML11AlgorithmId:
 			canonicalizer = MakeC14N11Canonicalizer()
 
+		case CanonicalXML10ExclusiveCommentAlgorithmId:
+			var prefixList string
+			if transform.InclusiveNamespaces != nil {
+				prefixList = transform.InclusiveNamespaces.PrefixList
+			}
+
+			canonicalizer = MakeC14N10ExclusiveCanonicalizerWithPrefixList(prefixList)
+
 		case CanonicalXML10RecAlgorithmId:
 			canonicalizer = MakeC14N10RecCanonicalizer()
 
@@ -373,6 +381,9 @@ func (ctx *ValidationContext) findSignature(root *etree.Element) (*types.Signatu
 					canonicalSignedInfo = canonicalPrep(detachedSignedInfo, map[string]struct{}{}, true)
 
 				case CanonicalXML10CommentAlgorithmId:
+					canonicalSignedInfo = canonicalPrep(detachedSignedInfo, map[string]struct{}{}, true)
+
+				case CanonicalXML10ExclusiveCommentAlgorithmId:
 					canonicalSignedInfo = canonicalPrep(detachedSignedInfo, map[string]struct{}{}, true)
 
 				default:

--- a/xml_constants.go
+++ b/xml_constants.go
@@ -47,8 +47,9 @@ const (
 //Well-known signature algorithms
 const (
 	// Supported canonicalization algorithms
-	CanonicalXML10ExclusiveAlgorithmId AlgorithmID = "http://www.w3.org/2001/10/xml-exc-c14n#"
-	CanonicalXML11AlgorithmId          AlgorithmID = "http://www.w3.org/2006/12/xml-c14n11"
+	CanonicalXML10ExclusiveAlgorithmId        AlgorithmID = "http://www.w3.org/2001/10/xml-exc-c14n#"
+	CanonicalXML10ExclusiveCommentAlgorithmId AlgorithmID = "http://www.w3.org/2001/10/xml-exc-c14n#WithComments"
+	CanonicalXML11AlgorithmId                 AlgorithmID = "http://www.w3.org/2006/12/xml-c14n11"
 
 	CanonicalXML10RecAlgorithmId     AlgorithmID = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315"
 	CanonicalXML10CommentAlgorithmId AlgorithmID = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments"


### PR DESCRIPTION
This PR includes support for http://www.w3.org/2001/10/xml-exc-c14n\#WithComments

Follow-up PR from https://github.com/russellhaering/goxmldsig/pull/38 which is deprecated. 

@russellhaering can you please take a look at it? I'm open to any suggestion and I would highly appreciate your feedback/approve/merge. Thanks buddy