### PR TITLE
Fix incorrect nil check in mapPathToElement

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -21,7 +21,7 @@ var (
 	// ErrMissingSignature indicates that no enveloped signature was found referencing
 	// the top level element passed for signature verification.
 	ErrMissingSignature = errors.New("Missing signature referencing the top-level element")
-	ErrInvalidSignature = errors.New( "Invalid Signature")
+	ErrInvalidSignature = errors.New("Invalid Signature")
 )
 
 type ValidationContext struct {
@@ -70,7 +70,7 @@ func mapPathToElement(tree, el *etree.Element) []int {
 	for i, child := range tree.Child {
 		if childElement, ok := child.(*etree.Element); ok {
 			childPath := mapPathToElement(childElement, el)
-			if childElement != nil {
+			if childPath != nil {
 				return append([]int{i}, childPath...)
 			}
 		}

--- a/validate_test.go
+++ b/validate_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/beevik/etree"
+	"github.com/russellhaering/goxmldsig/etreeutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -249,7 +250,6 @@ func TestValidateWithValid(t *testing.T) {
 	require.NotEmpty(t, el)
 }
 
-
 func TestValidateWithModified(t *testing.T) {
 	doc := etree.NewDocument()
 	err := doc.ReadFromBytes([]byte(modifiedToBeTodd))
@@ -268,7 +268,6 @@ func TestValidateWithModified(t *testing.T) {
 	require.Error(t, err)
 }
 
-
 func TestValidateWithModifiedAndSignatureEdited(t *testing.T) {
 	doc := etree.NewDocument()
 	err := doc.ReadFromBytes([]byte(spoofedAsTodd))
@@ -285,6 +284,24 @@ func TestValidateWithModifiedAndSignatureEdited(t *testing.T) {
 
 	_, err = vc.Validate(doc.Root())
 	require.Error(t, err)
+}
+
+func TestMapPathAndRemove(t *testing.T) {
+	doc := etree.NewDocument()
+	err := doc.ReadFromString(`<X><Y/><Y><RemoveMe xmlns="x"/></Y></X>`)
+	require.NoError(t, err)
+
+	el, err := etreeutils.NSFindOne(doc.Root(), "x", "RemoveMe")
+	require.NoError(t, err)
+	require.NotNil(t, el)
+
+	path := mapPathToElement(doc.Root(), el)
+	removed := removeElementAtPath(doc.Root(), path)
+	require.True(t, removed)
+
+	el, err = etreeutils.NSFindOne(doc.Root(), "x", "RemoveMe")
+	require.NoError(t, err)
+	require.Nil(t, el)
 }
 
 const (


### PR DESCRIPTION
The `mapPathToElement` function uses the wrong variable in a `nil` check:

```Go
			childPath := mapPathToElement(childElement, el)
			if childElement != nil {
```

The `childElement` variable is never `nil`; instead the check should be using the `childPath` variable. This may lead to the wrong element being removed during the enveloped transform.

This PR fixes that.