### PR TITLE
Fix deletion of attributes in-place

### DIFF
--- a/canonicalize.go
+++ b/canonicalize.go
@@ -140,19 +140,21 @@ func canonicalPrep(el *etree.Element, seenSoFar map[string]struct{}, strip bool)
 
 	ne := el.Copy()
 	sort.Sort(etreeutils.SortedAttrs(ne.Attr))
-	if len(ne.Attr) != 0 {
-		for _, attr := range ne.Attr {
-			if attr.Space != nsSpace {
-				continue
-			}
-			key := attr.Space + ":" + attr.Key
-			if _, seen := _seenSoFar[key]; seen {
-				ne.RemoveAttr(attr.Space + ":" + attr.Key)
-			} else {
-				_seenSoFar[key] = struct{}{}
-			}
+	n := 0
+	for _, attr := range ne.Attr {
+		if attr.Space != nsSpace {
+			ne.Attr[n] = attr
+			n++
+			continue
+		}
+		key := attr.Space + ":" + attr.Key
+		if _, seen := _seenSoFar[key]; !seen {
+			ne.Attr[n] = attr
+			n++
+			_seenSoFar[key] = struct{}{}
 		}
 	}
+	ne.Attr = ne.Attr[:n]
 
 	for i, token := range ne.Child {
 		childElement, ok := token.(*etree.Element)

--- a/canonicalize_test.go
+++ b/canonicalize_test.go
@@ -45,6 +45,12 @@ func TestXmldocC14N11(t *testing.T) {
 	runCanonicalizationTest(t, MakeC14N11Canonicalizer(), xmldoc, xmldocC14N11Canonicalized)
 }
 
+func TestNestedExcC14N11(t *testing.T) {
+	input := `<X xmlns:x="x" xmlns:y="y"><Y xmlns:x="x" xmlns:y="y" xmlns:z="z"/></X>`
+	expected := `<X xmlns:x="x" xmlns:y="y"><Y xmlns:z="z"></Y></X>`
+	runCanonicalizationTest(t, MakeC14N11Canonicalizer(), input, expected)
+}
+
 func TestExcC14nDefaultNamespace(t *testing.T) {
 	input := `<foo:Foo xmlns="urn:baz" xmlns:foo="urn:foo"><foo:Bar></foo:Bar></foo:Foo>`
 	expected := `<foo:Foo xmlns:foo="urn:foo"><foo:Bar></foo:Bar></foo:Foo>`


### PR DESCRIPTION
We were calling RemoveAttr while ranging the slice
which would call `a = append(a[:i], a[i+1:]...)`.
This incorrectly changes the array contents while the
slice range variable remains the same and therefore
incorrectly deleting the wrong attribute.

We fix this by properly implementing a slice filter in-place.