### PR TITLE
Fix SignedInfo order in findSignature method

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -387,8 +387,8 @@ func (ctx *ValidationContext) findSignature(root *etree.Element) (*types.Signatu
 					return fmt.Errorf("invalid CanonicalizationMethod on Signature: %s", c14NAlgorithm)
 				}
 
+				signatureEl.InsertChildAt(signedInfo.Index(), canonicalSignedInfo)
 				signatureEl.RemoveChild(signedInfo)
-				signatureEl.AddChild(canonicalSignedInfo)
 
 				found = true
 

--- a/validate_test.go
+++ b/validate_test.go
@@ -149,6 +149,26 @@ func TestDigest(t *testing.T) {
 
 }
 
+func TestFindSignature(t *testing.T) {
+	doc := etree.NewDocument()
+	err := doc.ReadFromBytes([]byte(rawResponse))
+	require.NoError(t, err)
+
+	vc := NewDefaultValidationContext(nil)
+
+	el := doc.Root()
+
+	sig, err := vc.findSignature(el)
+	require.NoError(t, err)
+	require.NotNil(t, sig)
+
+	children := sig.UnderlyingElement().ChildElements()
+	require.True(t, len(children) == 3)
+	require.Equal(t, "SignedInfo", children[0].Tag)
+	require.Equal(t, "SignatureValue", children[1].Tag)
+	require.Equal(t, "KeyInfo", children[2].Tag)
+}
+
 func TestTransform(t *testing.T) {
 	doc := etree.NewDocument()
 	err := doc.ReadFromBytes([]byte(rawResponse))


### PR DESCRIPTION
During findSignature index of SignedInfo is changed, fixed this to ensure same index for inserted canonical SignedInfo as removed one.