### PR TITLE
Add Manifest support according to the W3 standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,73 @@ func validate(root *x509.Certificate, el *etree.Element) {
 }
 ```
 
+### Working with Manifest
+
+```go
+package main
+
+import (
+    "crypto"
+    "github.com/beevik/etree"
+    "github.com/austdev/goxmldsig"
+    "github.com/austdev/goxmldsig/types"
+)
+
+func main() {
+    // Generate a key and self-signed certificate for signing
+    randomKeyStore := dsig.RandomKeyStoreForTest()
+    ctx := dsig.NewDefaultSigningContext(randomKeyStore)
+
+    digest := []byte{0x45, 0xf1, 0xab, 0xd7, 0x8a, 0x6f, 0x92, 0xe6, 0xa4, 0xb6, 0x8e, 0xba, 0x8f, 0xe7, 0x91, 0x96, 0xe0, 0xb2, 0x16, 0xd6, 0x0b, 0x82, 0x1b, 0x00, 0x45, 0xfa, 0xb8, 0xad, 0xd4, 0xfa, 0xff, 0xf9}
+
+    sig := ctx.CreateSignature("id1234")
+
+    // Get SHA256 hash of "package" data and add it as a reference
+    err := ctx.AddManifestRef(sig, "package", crypto.SHA256, digest)
+    if err != nil {
+        panic(err)
+    }
+
+    // Sign the signature
+    signed, err := ctx.Sign(sig)
+    if err != nil {
+        panic(err)
+    }
+
+    // Serialize the signature.
+    doc := etree.NewDocument()
+    doc.SetRoot(signed)
+    str, err := doc.WriteToString()
+    if err != nil {
+        panic(err)
+    }
+
+    println(str)
+}
+
+// Validate a signature against a root certificate
+func validate(root *x509.Certificate, sig *etree.Element) {
+    // Construct a signing context with one or more roots of trust.
+    ctx := dsig.NewDefaultValidationContext(&dsig.MemoryX509CertificateStore{
+        Roots: []*x509.Certificate{root},
+    })
+
+    manifest, err := ctx.ValidateManifest(signed)
+    if err != nil {
+        panic(err)
+    }
+
+    for idx := range manifest.References {
+        ref := &manifest.References[idx]
+        // Pass raw data of "package" for validating
+        err := ctx.VerifyReference(ref, test_data)
+        if err != nil {
+            panic(err)
+        }
+    }
+}
+```
+
 ## Limitations
 
 This library was created in order to [implement SAML 2.0](https://github.com/russellhaering/gosaml2)

--- a/etreeutils/canonicalize.go
+++ b/etreeutils/canonicalize.go
@@ -31,7 +31,7 @@ func transformExcC14n(ctx, declared NSContext, el *etree.Element, inclusiveNames
 	}
 
 	visiblyUtilizedPrefixes := map[string]struct{}{
-		el.Space: struct{}{},
+		el.Space: {},
 	}
 
 	filteredAttrs := []etree.Attr{}

--- a/etreeutils/namespace.go
+++ b/etreeutils/namespace.go
@@ -2,9 +2,7 @@ package etreeutils
 
 import (
 	"errors"
-
 	"fmt"
-
 	"sort"
 
 	"github.com/beevik/etree"
@@ -302,7 +300,7 @@ func NSFindOne(el *etree.Element, namespace, tag string) (*etree.Element, error)
 func NSFindOneCtx(ctx NSContext, el *etree.Element, namespace, tag string) (*etree.Element, error) {
 	var found *etree.Element
 
-	err := NSFindIterateCtx(ctx, el, namespace, tag, func(ctx NSContext, el *etree.Element) error {
+	err := NSFindIterateCtx(ctx, el, namespace, tag, func(_ NSContext, el *etree.Element) error {
 		found = el
 		return ErrTraversalHalted
 	})
@@ -376,7 +374,7 @@ func NSFindOneChild(el *etree.Element, namespace, tag string) (*etree.Element, e
 func NSFindOneChildCtx(ctx NSContext, el *etree.Element, namespace, tag string) (*etree.Element, error) {
 	var found *etree.Element
 
-	err := NSFindChildrenIterateCtx(ctx, el, namespace, tag, func(ctx NSContext, el *etree.Element) error {
+	err := NSFindChildrenIterateCtx(ctx, el, namespace, tag, func(_ NSContext, el *etree.Element) error {
 		found = el
 		return ErrTraversalHalted
 	})

--- a/etreeutils/unmarshal.go
+++ b/etreeutils/unmarshal.go
@@ -9,7 +9,7 @@ import (
 // NSUnmarshalElement unmarshals the passed etree Element into the value pointed to by
 // v using encoding/xml in the context of the passed NSContext. If v implements
 // ElementKeeper, SetUnderlyingElement will be called on v with a reference to el.
-func NSUnmarshalElement(ctx NSContext, el *etree.Element, v interface{}) error {
+func NSUnmarshalElement(ctx NSContext, root, el *etree.Element, v interface{}) error {
 	detatched, err := NSDetatch(ctx, el)
 	if err != nil {
 		return err
@@ -29,7 +29,7 @@ func NSUnmarshalElement(ctx NSContext, el *etree.Element, v interface{}) error {
 
 	switch v := v.(type) {
 	case ElementKeeper:
-		v.SetUnderlyingElement(el)
+		v.SetUnderlyingElement(root, el)
 	}
 
 	return nil
@@ -38,6 +38,6 @@ func NSUnmarshalElement(ctx NSContext, el *etree.Element, v interface{}) error {
 // ElementKeeper should be implemented by types which will be passed to
 // UnmarshalElement, but wish to keep a reference
 type ElementKeeper interface {
-	SetUnderlyingElement(*etree.Element)
+	SetUnderlyingElement(root, el *etree.Element)
 	UnderlyingElement() *etree.Element
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,46 @@
+package dsig
+
+import (
+	"crypto/x509"
+	"testing"
+
+	"github.com/beevik/etree"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDocumentedExample(t *testing.T) {
+
+	// Generate a key and self-signed certificate for signing
+	randomKeyStore := RandomKeyStoreForTest()
+	ctx := NewDefaultSigningContext(randomKeyStore)
+	elementToSign := &etree.Element{
+		Tag: "ExampleElement",
+	}
+	elementToSign.CreateAttr("ID", "id1234")
+
+	dataValue := elementToSign.CreateElement("XData")
+	dataValue.CreateAttr("kind", "test")
+	dataValue.SetText("zip: 586a6289e2ff09b0826dd1daeab5237735a3a728afc48d11976bbed1fbaeaf0a")
+
+	// Sign the element
+	signedElement, err := ctx.SignEnveloped(elementToSign)
+	require.NoError(t, err)
+
+	// Validate
+	_, certData, err := ctx.KeyStore.GetKeyPair()
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(certData)
+	require.NoError(t, err)
+
+	// Construct a signing context with one or more roots of trust.
+	vctx := NewDefaultValidationContext(&MemoryX509CertificateStore{
+		Roots: []*x509.Certificate{cert},
+	})
+
+	// It is important to only use the returned validated element.
+	// See: https://www.w3.org/TR/xmldsig-bestpractices/#check-what-is-signed
+	validated, err := vctx.Validate(signedElement)
+	require.NoError(t, err)
+	require.NotEmpty(t, validated)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -81,3 +81,53 @@ func TestManifestExample(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, manifest)
 }
+
+func TestRecursiveSigning(t *testing.T) {
+
+	// Generate a key and self-signed certificate for signing
+	randomKeyStore := RandomKeyStoreForTest()
+	ctx := NewDefaultSigningContext(randomKeyStore)
+
+	test := []byte{0x45, 0xf1, 0xab, 0xd7, 0x8a, 0x6f, 0x92, 0xe6, 0xa4, 0xb6, 0x8e, 0xba, 0x8f, 0xe7, 0x91, 0x96, 0xe0, 0xb2, 0x16, 0xd6, 0x0b, 0x82, 0x1b, 0x00, 0x45, 0xfa, 0xb8, 0xad, 0xd4, 0xfa, 0xff, 0xf9}
+
+	sig := ctx.CreateSignature("id1234")
+	err := ctx.AddManifestRef(sig, "package", crypto.SHA256, test)
+	require.NoError(t, err)
+
+	// Sign the signature
+	signed, err := ctx.Sign(sig)
+	require.NoError(t, err)
+
+	list := &etree.Element{Tag: "Signatures"}
+	list.AddChild(signed)
+
+	// create second layer
+	signed, err = ctx.SignEnveloped(list)
+	require.NoError(t, err)
+
+	// Validate
+	_, certData, err := ctx.KeyStore.GetKeyPair()
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(certData)
+	require.NoError(t, err)
+
+	// Construct a signing context with one or more roots of trust.
+	vctx := NewDefaultValidationContext(&MemoryX509CertificateStore{
+		Roots: []*x509.Certificate{cert},
+	})
+
+	// It is important to only use the returned validated element.
+	// See: https://www.w3.org/TR/xmldsig-bestpractices/#check-what-is-signed
+	manifest, err := vctx.ValidateManifest(signed)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, manifest)
+	require.Equal(t, len(manifest.References), 1)
+
+	hash, digest, err := vctx.DecodeRef(&manifest.References[0])
+
+	require.NoError(t, err)
+	require.Equal(t, digest, test)
+	require.Equal(t, hash, crypto.SHA256)
+}

--- a/sign.go
+++ b/sign.go
@@ -43,6 +43,47 @@ func (ctx *SigningContext) SetSignatureMethod(algorithmID string) error {
 	return nil
 }
 
+func (ctx *SigningContext) CreateSignature(id string) *etree.Element {
+
+	sig := &etree.Element{
+		Tag:   SignatureTag,
+		Space: ctx.Prefix,
+	}
+
+	xmlns := "xmlns"
+	if ctx.Prefix != "" {
+		xmlns += ":" + ctx.Prefix
+	}
+
+	sig.CreateAttr(xmlns, Namespace)
+
+	if ctx.IdAttribute != "" && id != "" {
+		sig.CreateAttr(ctx.IdAttribute, id)
+	}
+	return sig
+}
+
+func (ctx *SigningContext) AddManifestRef(sig *etree.Element, name string, hash_id crypto.Hash, digest []byte) error {
+
+	digestAlgorithmIdentifier, ok := digestAlgorithmIdentifiers[hash_id]
+	if !ok {
+		return ErrUnsupportedMethod
+	}
+
+	manifest := ctx.constructManifest(sig)
+	reference := ctx.createNamespacedElement(manifest, ReferenceTag)
+	if name != "" {
+		reference.CreateAttr(URIAttr, name)
+	}
+	digestMethod := ctx.createNamespacedElement(reference, DigestMethodTag)
+	digestMethod.CreateAttr(AlgorithmAttr, digestAlgorithmIdentifier)
+
+	digestValue := ctx.createNamespacedElement(reference, DigestValueTag)
+	digestValue.SetText(base64.StdEncoding.EncodeToString(digest))
+
+	return nil
+}
+
 func (ctx *SigningContext) digest(el *etree.Element) ([]byte, error) {
 	canonical, err := ctx.Canonicalizer.Canonicalize(el)
 	if err != nil {
@@ -56,6 +97,33 @@ func (ctx *SigningContext) digest(el *etree.Element) ([]byte, error) {
 	}
 
 	return hash.Sum(nil), nil
+}
+
+func (ctx *SigningContext) constructManifest(sig *etree.Element) *etree.Element {
+
+	man := sig.FindElementPath(ctx.manifestPath(sig))
+
+	if man == nil {
+		object := ctx.createNamespacedElement(sig, ObjectTag)
+		man = ctx.createNamespacedElement(object, ManifestTag)
+		if ctx.IdAttribute != "" {
+			man.CreateAttr(ctx.IdAttribute, ManifestPrefix+sig.SelectAttrValue(ctx.IdAttribute, ""))
+		}
+	}
+	return man
+}
+
+func (ctx *SigningContext) manifestPath(sig *etree.Element) etree.Path {
+
+	if ctx.IdAttribute != "" {
+		val := ManifestPrefix + sig.SelectAttrValue(ctx.IdAttribute, "")
+		pstr := fmt.Sprintf("%s/%s[@%s='%s']", ObjectTag, ManifestTag, ctx.IdAttribute, val)
+		if path, err := etree.CompilePath(pstr); err == nil {
+			return path
+		}
+	}
+	path, _ := etree.CompilePath(ObjectTag + "/" + ManifestTag)
+	return path
 }
 
 func (ctx *SigningContext) constructSignedInfo(el *etree.Element, enveloped bool) (*etree.Element, error) {
@@ -90,6 +158,11 @@ func (ctx *SigningContext) constructSignedInfo(el *etree.Element, enveloped bool
 	// /SignedInfo/Reference
 	reference := ctx.createNamespacedElement(signedInfo, ReferenceTag)
 
+	// additional signature syntax
+	if el.Tag == ManifestTag {
+		reference.CreateAttr(TypeAttr, ManifestRefType)
+	}
+
 	dataId := el.SelectAttrValue(ctx.IdAttribute, "")
 	if dataId == "" {
 		reference.CreateAttr(URIAttr, "")
@@ -119,22 +192,13 @@ func (ctx *SigningContext) constructSignedInfo(el *etree.Element, enveloped bool
 }
 
 func (ctx *SigningContext) ConstructSignature(el *etree.Element, enveloped bool) (*etree.Element, error) {
+
 	signedInfo, err := ctx.constructSignedInfo(el, enveloped)
 	if err != nil {
 		return nil, err
 	}
 
-	sig := &etree.Element{
-		Tag:   SignatureTag,
-		Space: ctx.Prefix,
-	}
-
-	xmlns := "xmlns"
-	if ctx.Prefix != "" {
-		xmlns += ":" + ctx.Prefix
-	}
-
-	sig.CreateAttr(xmlns, Namespace)
+	sig := ctx.CreateSignature("")
 	sig.AddChild(signedInfo)
 
 	// When using xml-c14n11 (ie, non-exclusive canonicalization) the canonical form
@@ -159,6 +223,11 @@ func (ctx *SigningContext) ConstructSignature(el *etree.Element, enveloped bool)
 	if err != nil {
 		return nil, err
 	}
+
+	return ctx.signing(sig, sigNSCtx, signedInfo)
+}
+
+func (ctx *SigningContext) signing(sig *etree.Element, sigNSCtx etreeutils.NSContext, signedInfo *etree.Element) (*etree.Element, error) {
 
 	// Finally detatch the SignedInfo in order to capture all of the namespace
 	// declarations in the scope we've constructed.
@@ -207,6 +276,37 @@ func (ctx *SigningContext) createNamespacedElement(el *etree.Element, tag string
 	child := el.CreateElement(tag)
 	child.Space = ctx.Prefix
 	return child
+}
+
+func (ctx *SigningContext) Sign(sig *etree.Element) (*etree.Element, error) {
+
+	// First get the default context
+	rootNSCtx := etreeutils.DefaultNSContext
+
+	// Followed by declarations on the Signature (which we just added above)
+	sigNSCtx, err := rootNSCtx.SubContext(sig)
+	if err != nil {
+		return nil, err
+	}
+
+	man := sig.FindElementPath(ctx.manifestPath(sig))
+	if err != nil {
+		return nil, err
+	}
+
+	manifest, err := etreeutils.NSDetatch(sigNSCtx, man)
+	if err != nil {
+		return nil, err
+	}
+
+	signedInfo, err := ctx.constructSignedInfo(manifest, false)
+	if err != nil {
+		return nil, err
+	}
+
+	sig.AddChild(signedInfo)
+
+	return ctx.signing(sig, sigNSCtx, signedInfo)
 }
 
 func (ctx *SigningContext) SignEnveloped(el *etree.Element) (*etree.Element, error) {

--- a/sign.go
+++ b/sign.go
@@ -35,7 +35,7 @@ func NewDefaultSigningContext(ks X509KeyStore) *SigningContext {
 func (ctx *SigningContext) SetSignatureMethod(algorithmID string) error {
 	hash, ok := signatureMethodsByIdentifier[algorithmID]
 	if !ok {
-		return fmt.Errorf("Unknown SignatureMethod: %s", algorithmID)
+		return fmt.Errorf("unknown SignatureMethod: %s", algorithmID)
 	}
 
 	ctx.Hash = hash

--- a/tls_keystore.go
+++ b/tls_keystore.go
@@ -8,8 +8,8 @@ import (
 
 //Well-known errors
 var (
-	ErrNonRSAKey           = fmt.Errorf("Private key was not RSA")
-	ErrMissingCertificates = fmt.Errorf("No public certificates provided")
+	ErrNonRSAKey           = fmt.Errorf("private key was not RSA")
+	ErrMissingCertificates = fmt.Errorf("no public certificates provided")
 )
 
 //TLSCertKeyStore wraps the stdlib tls.Certificate to return its contained key

--- a/types/signature.go
+++ b/types/signature.go
@@ -30,9 +30,15 @@ type DigestMethod struct {
 type Reference struct {
 	XMLName     xml.Name     `xml:"http://www.w3.org/2000/09/xmldsig# Reference"`
 	URI         string       `xml:"URI,attr"`
+	Type        string       `xml:"Type,attr"`
 	DigestValue string       `xml:"DigestValue"`
 	DigestAlgo  DigestMethod `xml:"DigestMethod"`
 	Transforms  Transforms   `xml:"Transforms"`
+}
+
+type Manifest struct {
+	XMLName    xml.Name    `xml:"http://www.w3.org/2000/09/xmldsig# Manifest"`
+	References []Reference `xml:"Reference"`
 }
 
 type CanonicalizationMethod struct {
@@ -78,6 +84,7 @@ type Signature struct {
 	SignatureValue *SignatureValue `xml:"SignatureValue"`
 	KeyInfo        *KeyInfo        `xml:"KeyInfo"`
 	el             *etree.Element
+	RootRef        *Reference
 }
 
 // SetUnderlyingElement will be called with a reference to the Element this Signature

--- a/types/signature.go
+++ b/types/signature.go
@@ -84,17 +84,65 @@ type Signature struct {
 	SignatureValue *SignatureValue `xml:"SignatureValue"`
 	KeyInfo        *KeyInfo        `xml:"KeyInfo"`
 	el             *etree.Element
+	path           []int
 	RootRef        *Reference
 }
 
 // SetUnderlyingElement will be called with a reference to the Element this Signature
 // was unmarshaled from.
-func (s *Signature) SetUnderlyingElement(el *etree.Element) {
+func (s *Signature) SetUnderlyingElement(root, el *etree.Element) {
 	s.el = el
+	// map the path to the passed signature relative to the passed root, in order
+	// to enable removal of the signature by an enveloped signature transform
+	s.path = mapPathToElement(root, el)
 }
 
 // UnderlyingElement returns a reference to the Element this signature was unmarshaled
 // from, where applicable.
 func (s *Signature) UnderlyingElement() *etree.Element {
 	return s.el
+}
+
+func (s *Signature) RemoveUnderlyingElement(el *etree.Element) bool {
+	return removeElementAtPath(el, s.path)
+}
+
+func mapPathToElement(tree, el *etree.Element) []int {
+	for i, child := range tree.Child {
+		if child == el {
+			return []int{i}
+		}
+	}
+
+	for i, child := range tree.Child {
+		if childElement, ok := child.(*etree.Element); ok {
+			childPath := mapPathToElement(childElement, el)
+			if childPath != nil {
+				return append([]int{i}, childPath...)
+			}
+		}
+	}
+
+	return nil
+}
+
+func removeElementAtPath(el *etree.Element, path []int) bool {
+
+	if len(path) == 0 {
+		return false
+	}
+
+	if path[0] < len(el.Child) {
+
+		if len(path) == 1 {
+			el.RemoveChildAt(path[0])
+			return true
+		}
+
+		childElement, ok := el.Child[path[0]].(*etree.Element)
+		if ok {
+			return removeElementAtPath(childElement, path[1:])
+		}
+	}
+	return false
 }

--- a/types/signature_test.go
+++ b/types/signature_test.go
@@ -1,0 +1,28 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/austdev/goxmldsig/etreeutils"
+
+	"github.com/beevik/etree"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapPathAndRemove(t *testing.T) {
+	doc := etree.NewDocument()
+	err := doc.ReadFromString(`<X><Y/><Y><RemoveMe xmlns="x"/></Y></X>`)
+	require.NoError(t, err)
+
+	el, err := etreeutils.NSFindOne(doc.Root(), "x", "RemoveMe")
+	require.NoError(t, err)
+	require.NotNil(t, el)
+
+	path := mapPathToElement(doc.Root(), el)
+	removed := removeElementAtPath(doc.Root(), path)
+	require.True(t, removed)
+
+	el, err = etreeutils.NSFindOne(doc.Root(), "x", "RemoveMe")
+	require.NoError(t, err)
+	require.Nil(t, el)
+}

--- a/validate.go
+++ b/validate.go
@@ -80,25 +80,24 @@ func mapPathToElement(tree, el *etree.Element) []int {
 }
 
 func removeElementAtPath(el *etree.Element, path []int) bool {
+	
 	if len(path) == 0 {
 		return false
 	}
 
-	if len(el.Child) <= path[0] {
-		return false
-	}
+	if path[0] < len(el.Child) {
 
-	childElement, ok := el.Child[path[0]].(*etree.Element)
-	if !ok {
-		return false
+		if len(path) == 1 {
+			el.RemoveChildAt(path[0])
+			return true
+		}
+		
+		childElement, ok := el.Child[path[0]].(*etree.Element)
+		if ok {
+			return removeElementAtPath(childElement, path[1:])
+		}
 	}
-
-	if len(path) == 1 {
-		el.RemoveChild(childElement)
-		return true
-	}
-
-	return removeElementAtPath(childElement, path[1:])
+	return false
 }
 
 // Transform returns a new element equivalent to the passed root el, but with

--- a/validate_test.go
+++ b/validate_test.go
@@ -286,24 +286,6 @@ func TestValidateWithModifiedAndSignatureEdited(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestMapPathAndRemove(t *testing.T) {
-	doc := etree.NewDocument()
-	err := doc.ReadFromString(`<X><Y/><Y><RemoveMe xmlns="x"/></Y></X>`)
-	require.NoError(t, err)
-
-	el, err := etreeutils.NSFindOne(doc.Root(), "x", "RemoveMe")
-	require.NoError(t, err)
-	require.NotNil(t, el)
-
-	path := mapPathToElement(doc.Root(), el)
-	removed := removeElementAtPath(doc.Root(), path)
-	require.True(t, removed)
-
-	el, err = etreeutils.NSFindOne(doc.Root(), "x", "RemoveMe")
-	require.NoError(t, err)
-	require.Nil(t, el)
-}
-
 const (
 	validExample = `<?xml version="1.0" encoding="UTF-8"?><saml2p:Response Destination="https://dev.sudo.wtf:8443/v1/_saml_callback" ID="id149481635007085371203272055" InResponseTo="_ffea96b1-44a2-4a86-9683-45807984ab5b" IssueInstant="2020-09-01T17:51:12.176Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema"><saml2:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity" xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://www.okta.com/exkrfkzzb7NyB3UeP0h7</saml2:Issuer><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><ds:Reference URI="#id149481635007085371203272055"><ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"><ec:InclusiveNamespaces PrefixList="xs" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transform></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><ds:DigestValue>LwRDkrPmsTcUa++BIS5VJIANUlZN7zzdtjLfxfLAWds=</ds:DigestValue></ds:Reference></ds:SignedInfo><ds:SignatureValue>UyjNRj9ZFbhApPhWEuVG26yACVqd25uyRKalSpp6XCdjrqKjI8Fmx7Q/IFkk5M755cxyFCQGttxThR6IPBk4Kp5OG2qGKXNHt7OQ8mumSLqWZpBJbmzNIKyG3nWlFoLVCoWPtBTd2gZM0aHOQp1JKa1birFBp2NofkEXbLeghZQ2YfCc4m8qgpZW5k/Itc0P/TVIkvPInjdSMyjm/ql4FUDO8cMkExJNR/i+GElW8cfnniWGcDPSiOqfIjLEDvZouXC7F1v5Wa0SmIxg7NJUTB+g6yrDN15VDq3KbHHTMlZXOZTXON2mBZOj5cwyyd4uX3aGSmYQiy/CGqBdqxrW2A==</ds:SignatureValue><ds:KeyInfo><ds:X509Data><ds:X509Certificate>MIIDnjCCAoagAwIBAgIGAXHxS90vMA0GCSqGSIb3DQEBCwUAMIGPMQswCQYDVQQGEwJVUzETMBEG
 A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU

--- a/xml_constants.go
+++ b/xml_constants.go
@@ -23,13 +23,17 @@ const (
 	X509DataTag               = "X509Data"
 	X509CertificateTag        = "X509Certificate"
 	InclusiveNamespacesTag    = "InclusiveNamespaces"
+	ObjectTag                 = "Object"
+	ManifestTag               = "Manifest"
 )
 
 const (
 	AlgorithmAttr  = "Algorithm"
+	TypeAttr       = "Type"
 	URIAttr        = "URI"
 	DefaultIdAttr  = "ID"
 	PrefixListAttr = "PrefixList"
+	ManifestPrefix = "Package"
 )
 
 type AlgorithmID string
@@ -44,7 +48,11 @@ const (
 	RSASHA512SignatureMethod = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512"
 )
 
-//Well-known signature algorithms
+const (
+	ManifestRefType = "http://www.w3.org/2000/09/xmldsig#Manifest"
+)
+
+// Well-known signature algorithms
 const (
 	// Supported canonicalization algorithms
 	CanonicalXML10ExclusiveAlgorithmId             AlgorithmID = "http://www.w3.org/2001/10/xml-exc-c14n#"


### PR DESCRIPTION
Add new methods for working with Manifest extension:

```go
func (ctx *SigningContext) CreateSignature(id string) *etree.Element
func (ctx *SigningContext) AddManifestRef(sig *etree.Element, name string, hash_id crypto.Hash, digest []byte) error

func (ctx *ValidationContext) ValidateManifest(sig *etree.Element) (*types.Manifest, error)
func (ctx *ValidationContext) VerifyReference(ref *types.Reference, data []byte) error
func (ctx *ValidationContext) DecodeRef(ref *types.Reference) (crypto.Hash, []byte, error)
```

An original API is preserved