### PR TITLE
docs: mention types.Signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ $ go get github.com/russellhaering/goxmldsig
 
 ## Usage
 
+Include the [`types.Signature`](https://pkg.go.dev/github.com/russellhaering/goxmldsig/types#Signature) struct from this package in your application messages.
+
+```go
+import (
+    sigtypes "github.com/russellhaering/goxmldsig/types"
+)
+
+type AppHdr struct {
+    ...
+    Signature *sigtypes.Signature
+}
+```
+
 ### Signing
 
 ```go


### PR DESCRIPTION
Thank you for this package @russellhaering as it helped me a ton when signing xml messages. It took longer than I'd like to admit that `types.Signature` can be used instead of my own structs. Adding this to help others in the future. 