### PR TITLE
Use crypto.Signer instead of *rsa.PrivateKey

### DIFF
--- a/keystore.go
+++ b/keystore.go
@@ -1,6 +1,7 @@
 package dsig
 
 import (
+	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -9,7 +10,7 @@ import (
 )
 
 type X509KeyStore interface {
-	GetKeyPair() (privateKey *rsa.PrivateKey, cert []byte, err error)
+	GetKeyPair() (privateKey crypto.Signer, cert []byte, err error)
 }
 
 type X509ChainStore interface {
@@ -29,11 +30,11 @@ func (mX509cs *MemoryX509CertificateStore) Certificates() ([]*x509.Certificate, 
 }
 
 type MemoryX509KeyStore struct {
-	privateKey *rsa.PrivateKey
+	privateKey crypto.Signer
 	cert       []byte
 }
 
-func (ks *MemoryX509KeyStore) GetKeyPair() (*rsa.PrivateKey, []byte, error) {
+func (ks *MemoryX509KeyStore) GetKeyPair() (crypto.Signer, []byte, error) {
 	return ks.privateKey, ks.cert, nil
 }
 

--- a/sign.go
+++ b/sign.go
@@ -115,7 +115,7 @@ func (ctx *SigningContext) signDigest(digest []byte) ([]byte, error) {
 			return nil, err
 		}
 
-		rawSignature, err := rsa.SignPKCS1v15(rand.Reader, key, ctx.Hash, digest)
+		rawSignature, err := key.Sign(rand.Reader, digest, ctx.Hash)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
X509KeyStore currently only supports RSA private keys due to the type used and was wondering if we could expand support to any `crypto.Signer`.

This is the minimal diff, but it is backward incompatible from an API perspective so merging would imply a v2. Alternatively, I could update the diff to introduce new types and maintain backward compatibility (but wanted to start a convo first before I went further with this).