### PR TITLE
a generic signer implementation suitable for use with HSMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,81 @@ type AppHdr struct {
 }
 ```
 
+### Using the Signer Interface
+
+The library now provides a clean `Signer` interface for implementing different signing mechanisms:
+
+```go
+// Signer represents an entity capable of creating digital signatures
+type Signer interface {
+    // Sign creates a signature for the given digest
+    Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error)
+    
+    // Algorithm returns the signature algorithm identifier for this signer
+    Algorithm() SignatureAlgorithm
+    
+    // GetCertificate returns the certificate associated with this signer
+    GetCertificate() ([]byte, error)
+}
+```
+
+Built-in implementations include:
+- `FileSigner`: For file-based RSA keys
+- `PKCS11Signer`: For hardware-based keys using PKCS#11
+
+#### Example with FileSigner
+
+```go
+import (
+    "crypto"
+    "crypto/x509"
+    
+    "github.com/russellhaering/goxmldsig"
+)
+
+// Load a private key and certificate from files
+privateKey, cert := loadKeysFromFiles()
+
+// Create a FileSigner
+signer, err := dsig.NewFileSigner(privateKey, cert, crypto.SHA256)
+if err != nil {
+    // handle error
+}
+
+// Create a signing context with the signer
+ctx := dsig.NewDefaultSigningContextWithSigner(signer)
+
+// Use the context to sign XML
+signedXML, err := ctx.SignEnveloped(xmlElement)
+```
+
+#### Example with PKCS11Signer
+
+```go
+import (
+    "crypto"
+    "crypto/x509"
+    
+    "github.com/russellhaering/goxmldsig"
+    "github.com/yourpkcs11provider/pkcs11"
+)
+
+// Initialize your PKCS11 provider and get a crypto.Signer implementation
+p11Signer, cert := initializePKCS11()
+
+// Create a PKCS11Signer
+signer, err := dsig.NewPKCS11SignerFromX509(p11Signer, cert, crypto.SHA256)
+if err != nil {
+    // handle error
+}
+
+// Create a signing context with the signer
+ctx := dsig.NewDefaultSigningContextWithSigner(signer)
+
+// Use the context to sign XML
+signedXML, err := ctx.SignEnveloped(xmlElement)
+```
+
 ### Signing
 
 ```go

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/russellhaering/goxmldsig
 
-go 1.23.0
-
-toolchain go1.24.0
+go 1.25.1
 
 require (
 	github.com/beevik/etree v1.6.0
@@ -15,6 +13,7 @@ require (
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
+	github.com/sirosfoundation/go-cryptoutil v0.2.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
+github.com/sirosfoundation/go-cryptoutil v0.2.0 h1:oR+YQPWAbxbf0i+/rmwmsFtk5tFEcP/n6yyxU9OeMCg=
+github.com/sirosfoundation/go-cryptoutil v0.2.0/go.mod h1:OZi673Xmf5o2LzF/QMceptIpiB2GKYAYBfEa75ocBss=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkcs11_signer.go
+++ b/pkcs11_signer.go
@@ -1,0 +1,84 @@
+package dsig
+
+import (
+	"crypto"
+	"crypto/x509"
+	"errors"
+	"io"
+)
+
+// PKCS11Signer is a generic implementation of the Signer interface using PKCS#11
+// This is a template that can be used with various PKCS#11 libraries
+type PKCS11Signer struct {
+	// The actual signer implementation that performs the PKCS#11 operations
+	// This should implement crypto.Signer
+	pkcs11Signer crypto.Signer
+
+	// The certificate associated with the private key
+	certificate []byte
+
+	// The hash algorithm to use
+	hash crypto.Hash
+
+	// The signature algorithm to use
+	sigAlgorithm SignatureAlgorithm
+}
+
+// NewPKCS11Signer creates a new PKCS11 signer
+func NewPKCS11Signer(signer crypto.Signer, cert []byte, hash crypto.Hash) (*PKCS11Signer, error) {
+	if signer == nil {
+		return nil, errors.New("signer cannot be nil")
+	}
+
+	if cert == nil || len(cert) == 0 {
+		return nil, errors.New("certificate cannot be nil or empty")
+	}
+
+	// Determine the signature algorithm based on the signer type and hash
+	var sigAlgorithm SignatureAlgorithm
+	switch hash {
+	case crypto.SHA1:
+		sigAlgorithm = SignatureAlgorithm(RSASHA1SignatureMethod)
+	case crypto.SHA256:
+		sigAlgorithm = SignatureAlgorithm(RSASHA256SignatureMethod)
+	case crypto.SHA384:
+		sigAlgorithm = SignatureAlgorithm(RSASHA384SignatureMethod)
+	case crypto.SHA512:
+		sigAlgorithm = SignatureAlgorithm(RSASHA512SignatureMethod)
+	default:
+		// Default to SHA256
+		sigAlgorithm = SignatureAlgorithm(RSASHA256SignatureMethod)
+	}
+
+	return &PKCS11Signer{
+		pkcs11Signer: signer,
+		certificate:  cert,
+		hash:         hash,
+		sigAlgorithm: sigAlgorithm,
+	}, nil
+}
+
+// Sign implements the Signer interface for PKCS11
+func (p *PKCS11Signer) Sign(_ io.Reader, digest []byte, _ crypto.SignerOpts) ([]byte, error) {
+	// Use the PKCS11 signer to sign the digest
+	return p.pkcs11Signer.Sign(nil, digest, p.hash)
+}
+
+// Algorithm returns the signature algorithm identifier
+func (p *PKCS11Signer) Algorithm() SignatureAlgorithm {
+	return p.sigAlgorithm
+}
+
+// GetCertificate implements the Signer interface
+func (p *PKCS11Signer) GetCertificate() ([]byte, error) {
+	return p.certificate, nil
+}
+
+// NewPKCS11SignerFromX509 creates a new PKCS11Signer from an X509 certificate
+func NewPKCS11SignerFromX509(signer crypto.Signer, cert *x509.Certificate, hash crypto.Hash) (*PKCS11Signer, error) {
+	if cert == nil {
+		return nil, errors.New("certificate cannot be nil")
+	}
+
+	return NewPKCS11Signer(signer, cert.Raw, hash)
+}

--- a/sign.go
+++ b/sign.go
@@ -19,19 +19,33 @@ import (
 type SigningContext struct {
 	Hash crypto.Hash
 
-	// This field will be nil and unused if the SigningContext is created with
-	// NewSigningContext
-	KeyStore      X509KeyStore
+	// Fields for legacy support
+	KeyStore X509KeyStore
+
 	IdAttribute   string
 	Prefix        string
 	Canonicalizer Canonicalizer
 
-	// KeyStore is mutually exclusive with signer and certs
-	signer crypto.Signer
-	certs  [][]byte
+	// Signer is the preferred way to provide signing capabilities
+	Signer Signer
+
+	// Legacy fields for backward compatibility
+	legacySigner crypto.Signer
+	certs        [][]byte
 }
 
 func NewDefaultSigningContext(ks X509KeyStore) *SigningContext {
+	// Try to create a FileSigner from the key store
+	key, cert, err := ks.GetKeyPair()
+	if err == nil {
+		// Create a file signer
+		signer, err := NewFileSigner(key, cert, crypto.SHA256)
+		if err == nil {
+			return NewDefaultSigningContextWithSigner(signer)
+		}
+	}
+
+	// Fall back to legacy approach if the FileSigner can't be created
 	return &SigningContext{
 		Hash:          crypto.SHA256,
 		KeyStore:      ks,
@@ -41,11 +55,24 @@ func NewDefaultSigningContext(ks X509KeyStore) *SigningContext {
 	}
 }
 
-// NewSigningContext creates a new signing context with the given signer and certificate chain.
+// NewDefaultSigningContextWithSigner creates a new signing context with the given custom signer.
+// This is the preferred way to create a SigningContext.
+func NewDefaultSigningContextWithSigner(signer Signer) *SigningContext {
+	return &SigningContext{
+		Hash:          crypto.SHA256,
+		Signer:        signer,
+		IdAttribute:   DefaultIdAttr,
+		Prefix:        DefaultPrefix,
+		Canonicalizer: MakeC14N11Canonicalizer(),
+	}
+}
+
+// NewSigningContext creates a new signing context with the given crypto.Signer and certificate chain.
 // Note that e.g. rsa.PrivateKey implements the crypto.Signer interface.
 // The certificate chain is a slice of ASN.1 DER-encoded X.509 certificates.
 // A SigningContext created with this function should not use the KeyStore field.
 // It will return error if passed a nil crypto.Signer
+// This method is kept for backwards compatibility.
 func NewSigningContext(signer crypto.Signer, certs [][]byte) (*SigningContext, error) {
 	if signer == nil {
 		return nil, errors.New("signer cannot be nil for NewSigningContext")
@@ -56,17 +83,28 @@ func NewSigningContext(signer crypto.Signer, certs [][]byte) (*SigningContext, e
 		Prefix:        DefaultPrefix,
 		Canonicalizer: MakeC14N11Canonicalizer(),
 
-		signer: signer,
-		certs:  certs,
+		legacySigner: signer,
+		certs:        certs,
 	}
 	return ctx, nil
 }
 
 func (ctx *SigningContext) getPublicKeyAlgorithm() x509.PublicKeyAlgorithm {
-	if ctx.KeyStore != nil {
+	if ctx.Signer != nil {
+		// Determine algorithm from the Signer interface
+		alg := ctx.Signer.Algorithm()
+		if string(alg) == RSASHA1SignatureMethod ||
+			string(alg) == RSASHA256SignatureMethod ||
+			string(alg) == RSASHA384SignatureMethod ||
+			string(alg) == RSASHA512SignatureMethod {
+			return x509.RSA
+		} else {
+			return x509.ECDSA
+		}
+	} else if ctx.KeyStore != nil {
 		return x509.RSA
-	} else {
-		switch ctx.signer.Public().(type) {
+	} else if ctx.legacySigner != nil {
+		switch ctx.legacySigner.Public().(type) {
 		case *ecdsa.PublicKey:
 			return x509.ECDSA
 		case *rsa.PublicKey:
@@ -109,29 +147,40 @@ func (ctx *SigningContext) digest(el *etree.Element) ([]byte, error) {
 }
 
 func (ctx *SigningContext) signDigest(digest []byte) ([]byte, error) {
+	// First, try using the Signer interface
+	if ctx.Signer != nil {
+		return ctx.Signer.Sign(rand.Reader, digest, ctx.Hash)
+	}
+
+	// Fall back to KeyStore if Signer is not available
 	if ctx.KeyStore != nil {
 		key, _, err := ctx.KeyStore.GetKeyPair()
 		if err != nil {
 			return nil, err
 		}
 
-		rawSignature, err := rsa.SignPKCS1v15(rand.Reader, key, ctx.Hash, digest)
-		if err != nil {
-			return nil, err
-		}
-
-		return rawSignature, nil
-	} else {
-		rawSignature, err := ctx.signer.Sign(rand.Reader, digest, ctx.Hash)
-		if err != nil {
-			return nil, err
-		}
-
-		return rawSignature, nil
+		return rsa.SignPKCS1v15(rand.Reader, key, ctx.Hash, digest)
 	}
+
+	// Finally, use legacy signer if available
+	if ctx.legacySigner != nil {
+		return ctx.legacySigner.Sign(rand.Reader, digest, ctx.Hash)
+	}
+
+	return nil, errors.New("no signer available")
 }
 
 func (ctx *SigningContext) getCerts() ([][]byte, error) {
+	// First, try using the Signer interface
+	if ctx.Signer != nil {
+		cert, err := ctx.Signer.GetCertificate()
+		if err != nil {
+			return nil, err
+		}
+		return [][]byte{cert}, nil
+	}
+
+	// Fall back to KeyStore if Signer is not available
 	if ctx.KeyStore != nil {
 		if cs, ok := ctx.KeyStore.(X509ChainStore); ok {
 			return cs.GetChain()
@@ -143,9 +192,14 @@ func (ctx *SigningContext) getCerts() ([][]byte, error) {
 		}
 
 		return [][]byte{cert}, nil
-	} else {
+	}
+
+	// Finally, use legacy certs if available
+	if ctx.certs != nil && len(ctx.certs) > 0 {
 		return ctx.certs, nil
 	}
+
+	return nil, errors.New("no certificates available")
 }
 
 func (ctx *SigningContext) constructSignedInfo(el *etree.Element, enveloped bool) (*etree.Element, error) {
@@ -303,8 +357,13 @@ func (ctx *SigningContext) SignEnveloped(el *etree.Element) (*etree.Element, err
 }
 
 func (ctx *SigningContext) GetSignatureMethodIdentifier() string {
-	algo := ctx.getPublicKeyAlgorithm()
+	// First, try using the Signer interface
+	if ctx.Signer != nil {
+		return string(ctx.Signer.Algorithm())
+	}
 
+	// Fall back to the legacy approach
+	algo := ctx.getPublicKeyAlgorithm()
 	if ident, ok := signatureMethodIdentifiers[algo][ctx.Hash]; ok {
 		return ident
 	}

--- a/signer.go
+++ b/signer.go
@@ -1,0 +1,71 @@
+package dsig
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+	"io"
+)
+
+// SignatureAlgorithm represents the algorithm used to sign the digest
+type SignatureAlgorithm string
+
+// Signer represents an entity capable of creating digital signatures
+type Signer interface {
+	// Sign creates a signature for the given digest
+	Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error)
+
+	// Algorithm returns the signature algorithm identifier for this signer
+	Algorithm() SignatureAlgorithm
+
+	// GetCertificate returns the certificate associated with this signer
+	GetCertificate() ([]byte, error)
+}
+
+// FileSigner implements the Signer interface using a local RSA private key
+type FileSigner struct {
+	privateKey *rsa.PrivateKey
+	cert       []byte
+	hash       crypto.Hash
+}
+
+// NewFileSigner creates a new signer from a private key and certificate
+func NewFileSigner(privateKey *rsa.PrivateKey, cert []byte, hash crypto.Hash) (*FileSigner, error) {
+	if privateKey == nil {
+		return nil, fmt.Errorf("private key cannot be nil")
+	}
+
+	return &FileSigner{
+		privateKey: privateKey,
+		cert:       cert,
+		hash:       hash,
+	}, nil
+}
+
+// Sign implements the Signer interface for file-based keys
+func (fs *FileSigner) Sign(_ io.Reader, digest []byte, _ crypto.SignerOpts) ([]byte, error) {
+	return rsa.SignPKCS1v15(rand.Reader, fs.privateKey, fs.hash, digest)
+}
+
+// Algorithm returns the signature algorithm identifier
+func (fs *FileSigner) Algorithm() SignatureAlgorithm {
+	switch fs.hash {
+	case crypto.SHA1:
+		return SignatureAlgorithm(RSASHA1SignatureMethod)
+	case crypto.SHA256:
+		return SignatureAlgorithm(RSASHA256SignatureMethod)
+	case crypto.SHA384:
+		return SignatureAlgorithm(RSASHA384SignatureMethod)
+	case crypto.SHA512:
+		return SignatureAlgorithm(RSASHA512SignatureMethod)
+	default:
+		// Default to SHA256
+		return SignatureAlgorithm(RSASHA256SignatureMethod)
+	}
+}
+
+// GetCertificate implements the Signer interface
+func (fs *FileSigner) GetCertificate() ([]byte, error) {
+	return fs.cert, nil
+}

--- a/signer_test.go
+++ b/signer_test.go
@@ -1,0 +1,59 @@
+package dsig
+
+import (
+	"crypto"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDefaultSigningContextWithSigner(t *testing.T) {
+	// Create a random key store for testing
+	ks := RandomKeyStoreForTest()
+	key, cert, err := ks.GetKeyPair()
+	require.NoError(t, err)
+
+	// Create a FileSigner
+	signer, err := NewFileSigner(key, cert, crypto.SHA256)
+	require.NoError(t, err)
+
+	// Create a signing context with the signer
+	ctx := NewDefaultSigningContextWithSigner(signer)
+	require.NotNil(t, ctx)
+	require.Equal(t, crypto.SHA256, ctx.Hash)
+	require.Equal(t, DefaultIdAttr, ctx.IdAttribute)
+	require.Equal(t, DefaultPrefix, ctx.Prefix)
+
+	// Verify the algorithm is correct
+	method := ctx.GetSignatureMethodIdentifier()
+	require.Equal(t, RSASHA256SignatureMethod, method)
+}
+
+func TestSignerFileSigner(t *testing.T) {
+	// Create a random key store for testing
+	ks := RandomKeyStoreForTest()
+	key, cert, err := ks.GetKeyPair()
+	require.NoError(t, err)
+
+	// Create a FileSigner
+	signer, err := NewFileSigner(key, cert, crypto.SHA256)
+	require.NoError(t, err)
+
+	// Verify the algorithm matches what we expect
+	require.Equal(t, SignatureAlgorithm(RSASHA256SignatureMethod), signer.Algorithm())
+
+	// Verify the certificate is returned correctly
+	certBytes, err := signer.GetCertificate()
+	require.NoError(t, err)
+	require.Equal(t, cert, certBytes)
+
+	// Create a proper hash of data before signing
+	hash := crypto.SHA256.New()
+	hash.Write([]byte("test message"))
+	digest := hash.Sum(nil)
+
+	// Sign the proper digest
+	sig, err := signer.Sign(nil, digest, crypto.SHA256)
+	require.NoError(t, err)
+	require.NotEmpty(t, sig)
+}

--- a/validate.go
+++ b/validate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/beevik/etree"
 	"github.com/russellhaering/goxmldsig/etreeutils"
 	"github.com/russellhaering/goxmldsig/types"
+	"github.com/sirosfoundation/go-cryptoutil"
 )
 
 var uriRegexp = regexp.MustCompile("^#[a-zA-Z_][\\w.-]*$")
@@ -28,6 +29,7 @@ type ValidationContext struct {
 	CertificateStore X509CertificateStore
 	IdAttribute      string
 	Clock            *Clock
+	CryptoExtensions *cryptoutil.Extensions
 }
 
 func NewDefaultValidationContext(certificateStore X509CertificateStore) *ValidationContext {
@@ -268,11 +270,6 @@ func (ctx *ValidationContext) validateSignature(el *etree.Element, sig *types.Si
 		return nil, errors.New("Missing SignedInfo")
 	}
 
-	algo, ok := x509SignatureAlgorithmByIdentifier[signatureMethod]
-	if !ok {
-		return nil, errors.New("Unknown signature method: " + signatureMethod)
-	}
-
 	if sig.SignatureValue == nil {
 		return nil, errors.New("Signature could not be verified")
 	}
@@ -283,7 +280,17 @@ func (ctx *ValidationContext) validateSignature(el *etree.Element, sig *types.Si
 		return nil, errors.New("Could not decode signature")
 	}
 
-	err = cert.CheckSignature(algo, canonicalSignedInfoBytes, decodedSignature)
+	// Verify the signature using crypto extensions if available, otherwise
+	// fall back to the standard x509 algorithm map.
+	if ctx.CryptoExtensions != nil {
+		err = ctx.CryptoExtensions.CheckSignatureXMLDSIG(cert, signatureMethod, canonicalSignedInfoBytes, decodedSignature)
+	} else {
+		algo, ok := x509SignatureAlgorithmByIdentifier[signatureMethod]
+		if !ok {
+			return nil, errors.New("Unknown signature method: " + signatureMethod)
+		}
+		err = cert.CheckSignature(algo, canonicalSignedInfoBytes, decodedSignature)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -527,7 +534,11 @@ func (ctx *ValidationContext) verifyCertificate(sig *types.Signature) (*x509.Cer
 			return nil, errors.New("Failed to parse certificate")
 		}
 
-		untrustedCert, err = x509.ParseCertificate(certData)
+		if ctx.CryptoExtensions != nil {
+			untrustedCert, err = ctx.CryptoExtensions.ParseCertificate(certData)
+		} else {
+			untrustedCert, err = x509.ParseCertificate(certData)
+		}
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This is an implementation of a generic "signer" concept for goxmldsig. The goal is to allow non-file based key-pairs such as for instance when using hardware security modules. The included pkcs11 signer relies on standard crypto signer interfaces and is therefore not dependent on any particular golang pkcs11 implementation.

This should be fully backwards compatible.