### PR TITLE
Bump github.com/beevik/etree to v1.7.0

### DIFF
--- a/etreeutils/namespace_test.go
+++ b/etreeutils/namespace_test.go
@@ -1,29 +1,27 @@
 package etreeutils
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/beevik/etree"
 	"github.com/stretchr/testify/require"
 )
 
+// nestedElement builds the tree directly rather than parsing it, so that the
+// depth under test stays independent of etree's ReadSettings.MaxDepth.
 func nestedElement(t *testing.T, depth int) *etree.Element {
 	t.Helper()
 
-	var b strings.Builder
-	b.WriteString(`<root xmlns="http://example.org">`)
-	for i := 0; i < depth; i++ {
-		b.WriteString("<a>")
-	}
-	for i := 0; i < depth; i++ {
-		b.WriteString("</a>")
-	}
-	b.WriteString(`</root>`)
-
 	doc := etree.NewDocument()
-	require.NoError(t, doc.ReadFromString(b.String()))
-	return doc.Root()
+	root := doc.CreateElement("root")
+	root.CreateAttr("xmlns", "http://example.org")
+
+	el := root
+	for i := 0; i < depth; i++ {
+		el = el.CreateElement("a")
+	}
+
+	return root
 }
 
 func TestNSDetatchLimit(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.24.0
 
 require (
-	github.com/beevik/etree v1.6.0
+	github.com/beevik/etree v1.7.0
 	github.com/jonboulle/clockwork v0.5.0
 	github.com/stretchr/testify v1.8.4
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/beevik/etree v1.6.0 h1:u8Kwy8pp9D9XeITj2Z0XtA5qqZEmtJtuXZRQi+j03eE=
-github.com/beevik/etree v1.6.0/go.mod h1:bh4zJxiIr62SOf9pRzN7UUYaEDa9HEKafK25+sLc0Gc=
+github.com/beevik/etree v1.7.0 h1:xjBk9O4p4x7D1YajePjfLzdaFC4/uYUENA7P0pv6gXA=
+github.com/beevik/etree v1.7.0/go.mod h1:bh4zJxiIr62SOf9pRzN7UUYaEDa9HEKafK25+sLc0Gc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Updates etree to v1.7.0, which remediates three security advisories affecting v1.6.0 and earlier.

| Advisory | Severity | Issue |
| --- | --- | --- |
| [GHSA-qm2r-qg5g-crr3](https://github.com/beevik/etree/security/advisories/GHSA-qm2r-qg5g-crr3) | High (7.5) | Unrecoverable stack overflow when serializing or copying deeply nested XML |
| [GHSA-2mj8-7fmf-pr7x](https://github.com/beevik/etree/security/advisories/GHSA-2mj8-7fmf-pr7x) | Medium (5.9) | XML structure injection via unescaped CDATA / comment / directive / processing instruction contents |
| [GHSA-f965-f62m-c42m](https://github.com/beevik/etree/security/advisories/GHSA-f965-f62m-c42m) | Low (3.7) | Index out of range panic in `CompilePath` on a malformed filter expression |

Only the first is reachable from this library. We call `Copy` and `WriteTo` on caller-supplied documents throughout validation and signing, which is the pattern that advisory describes; the crash is a stack overflow, so callers cannot recover from it. We never construct CDATA, comments, directives or processing instructions, and never compile paths, so the other two do not apply.

Worth noting that none of the three have been picked up by the Go vulnerability database yet, so `govulncheck` stays quiet on them — this is not something Dependabot's security updates will raise on its own.

## The test change

v1.7.0 adds `ReadSettings.MaxDepth`, defaulting to 1024. That breaks `TestNSDetatchLimit` as written: it builds a 5000-deep document by parsing an XML string, so the parser now rejects the input before `NSDetatch` is ever reached, and the test fails with `etree: XML tree exceeds maximum depth` instead of the `ErrTraversalLimit` it is asserting on.

Since our own traversal limit is 1000 and etree's parse limit is 1024, just lowering the depth would leave a 24-element window between the two and would break again on any future change to either limit. Instead the first commit builds the tree directly via `CreateElement`, so the test depends only on the limit it is actually exercising.

The commits are ordered so both are independently green: the test change alone passes against v1.6.0, and the bump alone passes on top of it. Verified the refactored test still fails against the pre-fix `NSDetatch` (`878c8c6`), so it has not been defanged.

`go test ./...` and `go vet ./...` pass. The etreeutils and root fuzz targets were run as a smoke test with no crashers.

Deliberately not included: the `stretchr/testify` 1.8.4 → 1.11.1 bump, which is unrelated to these advisories and already covered by #174.