### PR TITLE
Pin test workflow actions by commit SHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         go: ['1.26', '1.25', '1.24', '1.23']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ matrix.go }}
       - name: Test


### PR DESCRIPTION
Follow-up to #197, which I left out of that PR because it is a style change rather than a version bump.

`scorecard.yml` already pinned its actions by commit SHA, but `test.yml` referred to them by moving major tag. That is inconsistent between the two workflows, and it costs a point on the OpenSSF Scorecard Pinned-Dependencies check that this repository publishes results for. A moving tag can also be repointed at different code after the fact, which is the underlying reason the check exists.

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `@v7` | `@3d3c42e5aac5ba805825da76410c181273ba90b1` (v7.0.1) |
| `actions/setup-go` | `@v7` | `@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e` (v7.0.0) |

Both SHAs were resolved from their release tags and verified back through the API, so the trailing comments are accurate. After this, `grep` finds no unpinned `uses:` reference anywhere in `.github/workflows/`.

This does not make the actions harder to keep current: `.github/dependabot.yml` already watches the `github-actions` ecosystem weekly, and Dependabot updates SHA pins together with their trailing version comments exactly as it does tags.

No version changes and no library code — the actions are the same releases #197 landed on. `test.yml` parses as valid YAML.